### PR TITLE
Bump maven-core to 3.6.3 and warn if affected by MNG-6173 (3.3.1-3.3.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-
----
-:information_source: **This repo has moved**
-
-`gitflow-incremental-builder` has moved to its own GitHub organization to enable administration by multiple users for better maintainability. <br />
-In case you forked this repo when it was still known as `vackosar/gitflow-incremental-builder`, you might need to adjust your upstream setting to `gitflow-incremental-builder/gitflow-incremental-builder`.
-
----
-
 # gitflow-incremental-builder (GIB)
 [![GitHub license](https://img.shields.io/github/license/gitflow-incremental-builder/gitflow-incremental-builder.svg)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/blob/master/LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/gitflow-incremental-builder/gitflow-incremental-builder?label=latest%20release)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/latest)
@@ -23,6 +14,8 @@ Powered by [JGit](https://www.eclipse.org/jgit/).
 This extension is **not limited to Git Flow setups!** The [extensive configuration options](#configuration) provide support for many other branch setups and/or use cases. 
 
 ## Table of Contents
+
+- [Requirements](#requirements)
 
 - [Usage](#usage)
   - [Usage as a Maven extension](#usage-as-a-maven-extension)
@@ -70,7 +63,15 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
   - [HTTP](#http)
   - [SSH](#ssh)
 
-- [Requirements](#requirements)
+## Requirements
+
+To be able to use GIB, your project must use:
+
+- **Apache Maven** build tool, version **3.6.3** is recommended
+  - GIB is also tested with Maven 3.5.4 and 3.3.9, but 3.3.9 is _not recommended_ in case you want to use `mvn -pl`/`--projects` (see [issue 324](../../issues/324) and [MNG-6173](https://issues.apache.org/jira/browse/MNG-6173))
+  - GIB _might_ work with Maven down to version 3.1.0
+
+- **Git** version control
 
 ## Usage
 
@@ -715,8 +716,3 @@ GIB then uses [`jsch-agent-proxy`](https://github.com/ymnk/jsch-agent-proxy) to 
 See also [AgentProxyAwareJschConfigSessionFactory](../master/src/main/java/com/vackosar/gitflowincrementalbuild/control/jgit/AgentProxyAwareJschConfigSessionFactory.java).
 
 Hint: When using an agent, you don't need to put your key in a standard location, you don't need `~/.ssh/config` and your key is also _not required_ to be passphrase protected.
-
-## Requirements
-
-- Maven version 3.3.9+ is recommended (however, GIB _might_ work with Maven down to version 3.1.0)
-- Project must use Git

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
     <artifactId>gitflow-incremental-builder</artifactId>
-    <version>3.12.3-SNAPSHOT</version>
+    <version>3.13.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A Maven extension for incremental building of multi-module projects when using Git Flow (or Git in general).</description>
     <url>https://github.com/gitflow-incremental-builder/gitflow-incremental-builder</url>
@@ -60,10 +60,11 @@
         <!-- Dependency versions -->
         <version.jgit>5.10.0.202012080955-r</version.jgit>
         <version.jsch.agentproxy>0.0.9</version.jsch.agentproxy>
-        <version.maven-core>3.3.9</version.maven-core>
+        <version.maven-core>3.6.3</version.maven-core>
+        <version.maven-enforced>3.3.9</version.maven-enforced>
         <version.maven-plugin>3.6.0</version.maven-plugin>
-        <version.slf4j>1.7.5</version.slf4j>    <!-- must match the version that is provided by maven -->
-        <version.logback>1.1.3</version.logback>    <!-- the latest that appears to work properly with slf4j 1.7.5 -->
+        <version.slf4j>1.7.29</version.slf4j>   <!-- must match the version that is provided by maven -->
+        <version.logback>1.2.3</version.logback>    <!-- the latest that appears to work properly with above slf4j version -->
         <version.javax.inject>1</version.javax.inject>
         <version.bytebuddy>1.10.22</version.bytebuddy>
         <version.junit>5.7.1</version.junit>
@@ -451,7 +452,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[${version.maven-core},)</version>
+                                    <version>[${version.maven-enforced},)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Related to #321 & #324.

The bump does not prevent GIB from running on <3.6.3. It makes debugging in Maven 3.6.3 (the default these days) much easier.

GIB now logs a warning on Maven 3.3.1-3.3.9 regarding https://issues.apache.org/jira/browse/MNG-6173.