### PR TITLE
CI: leverage cache action instead of explicit upload/download

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -82,19 +82,6 @@ jobs:
         path: test-reports-${{ env.JOB_NAME }}.tgz
         if-no-files-found: ignore
         retention-days: 30
-    - name: Tar Maven Repo for secondary jobs
-      # secondary jobs are not run in forks, so no use to create the repo
-      if: github.repository == 'gitflow-incremental-builder/gitflow-incremental-builder' || github.event.inputs.runSecondary == 'yes'
-      shell: bash
-      run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-    - name: Upload Maven Repo for secondary jobs
-      uses: actions/upload-artifact@v2
-      # secondary jobs are not run in forks, so no use to upload the repo
-      if: github.repository == 'gitflow-incremental-builder/gitflow-incremental-builder' || github.event.inputs.runSecondary == 'yes'
-      with:
-        name: maven-repo
-        path: maven-repo.tgz
-        retention-days: 1
 
   secondary:
     name: ${{ matrix.java-maven.name }}
@@ -164,14 +151,13 @@ jobs:
     - name: Print Java & Maven version
       shell: bash
       run: mvn --version
-    - name: Download Maven Repo
-      uses: actions/download-artifact@v2
+    - name: Cache Maven Repository
+      uses: actions/cache@v2
       with:
-        name: maven-repo
-        path: .
-    - name: Extract Maven Repo
-      shell: bash
-      run: tar -xzf maven-repo.tgz -C ~
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Maven test
       shell: bash
       # see primary job notes regarding ssh-agent


### PR DESCRIPTION
Reduces the "bloat" to have secondary jobs running with a pre-populated local Maven repo.