### PR TITLE
Raise Java requirement from 8 to 11, drop support for Maven 3.6.2 and before, update jetty for tests to 10.0.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,10 @@ updates:
     - dependency-name: org.slf4j:slf4j-api
       versions:
       - ">= 0"
-    # https://webtide.com/jetty-10-and-11-have-arrived/ (Java 8 support still needed)
+    # https://webtide.com/jetty-10-and-11-have-arrived/ (javax support still needed for JGit GitServlet)
     - dependency-name: org.eclipse.jetty:jetty-server
       versions:
-      - ">= 10.0.0"
+      - ">= 11.0.0"
     - dependency-name: org.eclipse.jetty:jetty-servlet
       versions:
-      - ">= 10.0.0"
+      - ">= 11.0.0"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -108,16 +108,6 @@ jobs:
             maven-version: 3.6.3
           }
           - {
-            name: "JDK 11 & Maven 3.5.4",
-            java-version: 11,
-            maven-version: 3.5.4
-          }
-          - {
-            name: "JDK 11 & Maven 3.3.9",
-            java-version: 11,
-            maven-version: 3.3.9
-          }
-          - {
             name: "JDK 17 & Maven 3.8.4",
             java-version: 17,
             maven-version: 3.8.4
@@ -126,16 +116,6 @@ jobs:
             name: "JDK 17 & Maven 3.6.3",
             java-version: 17,
             maven-version: 3.6.3
-          }
-          - {
-            name: "JDK 17 & Maven 3.5.4",
-            java-version: 17,
-            maven-version: 3.5.4
-          }
-          - {
-            name: "JDK 17 & Maven 3.3.9",
-            java-version: 17,
-            maven-version: 3.3.9
           }
           - {
             name: "JDK 18 EA & Maven 3.8.4",

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -118,29 +118,24 @@ jobs:
             maven-version: 3.3.9
           }
           - {
-            name: "JDK 8 & Maven 3.8.4",
-            java-version: 8,
-            maven-version: 3.8.4
-          }
-          - {
-            name: "JDK 8 & Maven 3.6.3",
-            java-version: 8,
-            maven-version: 3.6.3
-          }
-          - {
-            name: "JDK 8 & Maven 3.5.4",
-            java-version: 8,
-            maven-version: 3.5.4
-          }
-          - {
-            name: "JDK 8 & Maven 3.3.9",
-            java-version: 8,
-            maven-version: 3.3.9
-          }
-          - {
             name: "JDK 17 & Maven 3.8.4",
             java-version: 17,
             maven-version: 3.8.4
+          }
+          - {
+            name: "JDK 17 & Maven 3.6.3",
+            java-version: 17,
+            maven-version: 3.6.3
+          }
+          - {
+            name: "JDK 17 & Maven 3.5.4",
+            java-version: 17,
+            maven-version: 3.5.4
+          }
+          - {
+            name: "JDK 17 & Maven 3.3.9",
+            java-version: 17,
+            maven-version: 3.3.9
           }
           - {
             name: "JDK 18 EA & Maven 3.8.4",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/workflows/CI/badge.svg)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/actions?query=workflow%3A%22CI%22+branch%3Amaster)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2a74eedd5e0c4694ac8cf44b315cfb5a)](https://www.codacy.com/gh/gitflow-incremental-builder/gitflow-incremental-builder/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=gitflow-incremental-builder/gitflow-incremental-builder&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/2a74eedd5e0c4694ac8cf44b315cfb5a)](https://www.codacy.com/gh/gitflow-incremental-builder/gitflow-incremental-builder/dashboard?utm_source=github.com&utm_medium=referral&utm_content=gitflow-incremental-builder/gitflow-incremental-builder&utm_campaign=Badge_Coverage)
-[![Supported JVM Versions](https://img.shields.io/badge/JVM-8--17-brightgreen.svg?logo=Java)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/actions?query=workflow%3A%22CI%22+branch%3Amaster)
+[![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17-brightgreen.svg?logo=Java)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/actions?query=workflow%3A%22CI%22+branch%3Amaster)
 [![GitHub Discussions](https://img.shields.io/github/discussions/gitflow-incremental-builder/gitflow-incremental-builder)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/discussions)
 
 ----

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
 To be able to use GIB, your project must use:
 
 - **Apache Maven** build tool, version **3.8.4** is recommended
-  - GIB is also tested with Maven 3.6.3, 3.5.4 and 3.3.9, but 3.3.9 is _not recommended_ in case you want to use `mvn -pl`/`--projects` (see [issue 324](../../issues/324) and [MNG-6173](https://issues.apache.org/jira/browse/MNG-6173))
-  - GIB _might_ work with Maven down to version 3.1.0
+  - The minimum Maven version is 3.6.3 due to [MNG-6580](https://issues.apache.org/jira/browse/MNG-6580)
 
 - **Git** version control
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <!-- workaround until https://github.com/raphw/byte-buddy/pull/1181 is available -->
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
 
         <!-- Dependency versions -->
         <version.jgit>5.13.0.202109080827-r</version.jgit>
@@ -70,7 +71,7 @@
         <version.junit>5.8.2</version.junit>
         <version.assertj>3.21.0</version.assertj>
         <version.mockito>4.2.0</version.mockito>
-        <version.jetty>9.4.44.v20210927</version.jetty>
+        <version.jetty>10.0.7</version.jetty>
 
         <!-- Plugin versions -->
         <version.maven-enforcer-plugin>3.0.0</version.maven-enforcer-plugin>
@@ -746,16 +747,6 @@
         </plugins>
     </build>
     <profiles>
-        <!-- verify that only JDK8 APIs are used -->
-        <profile>
-            <id>jdk9+</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-        </profile>
         <profile>
             <id>quick-build</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.jgit>5.13.0.202109080827-r</version.jgit>
         <version.jsch.agentproxy>0.0.9</version.jsch.agentproxy>
         <version.maven-core>3.8.4</version.maven-core>
-        <version.maven-enforced>3.3.9</version.maven-enforced>
+        <version.maven-enforced>3.6.3</version.maven-enforced>
         <version.maven-plugin>3.6.2</version.maven-plugin>
         <version.slf4j>1.7.32</version.slf4j>   <!-- must match the version that is provided by maven -->
         <version.logback>1.2.9</version.logback>    <!-- the latest that appears to work properly with above slf4j version -->

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -301,12 +301,7 @@ public class Configuration {
     private static Optional<Predicate<String>> compileOptionalPatternPredicate(Property property, Properties pluginProperties, Properties projectProperties) {
         return property.getValueOpt(pluginProperties, projectProperties)
                 .map(patternString -> compilePattern(patternString, property))
-                .map(Configuration::asMatchPredicate);
-    }
-
-    // for Java 8-10 compatibility, Java 11 has Pattern.asMatchPredicate() OOTB
-    private static Predicate<String> asMatchPredicate(Pattern pattern) {
-        return s -> pattern.matcher(s).matches();
+                .map(Pattern::asMatchPredicate);
     }
 
     public static enum BuildUpstreamMode {

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipant.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipant.java
@@ -123,15 +123,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
     void warnIfBuggyOrUnsupportedMavenVersion(String mavenVersion, Configuration config) {
         if (mavenVersion == null) {
             logger.warn("Could not get Maven version.");
-        } else if (mavenVersion.startsWith("3.8.") || mavenVersion.startsWith("3.6.") || mavenVersion.startsWith("3.5.")) {
-            // all is well, 3.8.1 should be the default case these days (therefore this check is up here for a "quick exit")
-        } else if (mavenVersion.startsWith("3.3.")) {
-            if (!mavenVersion.equals("3.3.0")
-                    && (config.disableSelectedProjectsHandling || !config.mavenSession.getRequest().getSelectedProjects().isEmpty())) {
-                logger.warn("Detected Maven {} is affected by https://issues.apache.org/jira/browse/MNG-6173.", mavenVersion);
-                logger.warn("More details: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/324");
-            }
-        } else {
+        } else if (!mavenVersion.startsWith("3.8.") && !mavenVersion.equals("3.6.3")) {
             logger.warn("Detected Maven {} was not tested with gitflow-incremental-builder.", mavenVersion);
         }
     }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
@@ -244,6 +244,13 @@ public class MavenLifecycleParticipantTest {
     }
 
     @Test
+    public void warnIfBuggyOrUnsupportedMavenVersion_384() {
+        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.8.4", new Configuration(mavenSessionMock));
+
+        verifyNoInteractions(loggerSpy);
+    }
+
+    @Test
     public void warnIfBuggyOrUnsupportedMavenVersion_381() {
         underTest.warnIfBuggyOrUnsupportedMavenVersion("3.8.1", new Configuration(mavenSessionMock));
 
@@ -258,42 +265,24 @@ public class MavenLifecycleParticipantTest {
     }
 
     @Test
-    public void warnIfBuggyOrUnsupportedMavenVersion_354() {
-        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.5.4", new Configuration(mavenSessionMock));
+    public void warnIfBuggyOrUnsupportedMavenVersion_362() {
+        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.6.2", new Configuration(mavenSessionMock));
 
-        verifyNoInteractions(loggerSpy);
+        verify(loggerSpy).warn(contains("not tested"), eq("3.6.2"));
     }
 
     @Test
-    public void warnIfBuggyOrUnsupportedMavenVersion_330() {
-        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.3.0", new Configuration(mavenSessionMock));
+    public void warnIfBuggyOrUnsupportedMavenVersion_354() {
+        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.5.4", new Configuration(mavenSessionMock));
 
-        verifyNoInteractions(loggerSpy);
+        verify(loggerSpy).warn(contains("not tested"), eq("3.5.4"));
     }
 
     @Test
     public void warnIfBuggyOrUnsupportedMavenVersion_339() {
         underTest.warnIfBuggyOrUnsupportedMavenVersion("3.3.9", new Configuration(mavenSessionMock));
 
-        verifyNoInteractions(loggerSpy);
-    }
-
-    @Test
-    public void warnIfBuggyOrUnsupportedMavenVersion_339_withSelectedProject() {
-        when(execRequestMock.getSelectedProjects()).thenReturn(Collections.singletonList("foo"));
-
-        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.3.9", new Configuration(mavenSessionMock));
-
-        verify(loggerSpy).warn(contains("MNG-6173"), eq("3.3.9"));
-    }
-
-    @Test
-    public void warnIfBuggyOrUnsupportedMavenVersion_339_withDisableSelectedProjectsHandling() {
-        projectProperties.setProperty(Property.disableSelectedProjectsHandling.prefixedName(), "true");
-
-        underTest.warnIfBuggyOrUnsupportedMavenVersion("3.3.9", new Configuration(mavenSessionMock));
-
-        verify(loggerSpy).warn(contains("MNG-6173"), eq("3.3.9"));
+        verify(loggerSpy).warn(contains("not tested"), eq("3.3.9"));
     }
 
     @Test

--- a/src/test/resources/build-parent/pom-common.xml
+++ b/src/test/resources/build-parent/pom-common.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
         <!-- These properties are needed by pom.xml files within template.zip: -->
         <version.jgit>${version.jgit}</version.jgit>
     </properties>


### PR DESCRIPTION
Resolves #425 & #324

The Maven support bump is a consequence of the minimum Java version of 11; https://issues.apache.org/jira/browse/MNG-6580