### PR TITLE
fix: handle case of no defined configuration in maven-jar-plugin test…

### DIFF
--- a/src/main/java/io/github/gitflowincrementalbuilder/DownstreamCalculator.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/DownstreamCalculator.java
@@ -171,7 +171,10 @@ class DownstreamCalculator {
                 .filter(p -> "maven-jar-plugin".equals(p.getArtifactId()))
                 .flatMap(p -> p.getExecutions().stream().filter(e -> e.getGoals().contains(TEST_JAR)))
                 .map(e -> (Xpp3Dom) e.getConfiguration())
-                .map(d -> Optional.ofNullable(d.getChild("classifier")).map(Xpp3Dom::getValue).orElse(TEST_JAR_DEFAULT_CLASSIFIER))
+                .map(d -> Optional.ofNullable(d)
+		                .map(xpp3Dom -> xpp3Dom.getChild("classifier"))
+		                .map(Xpp3Dom::getValue)
+		                .orElse(TEST_JAR_DEFAULT_CLASSIFIER))
                 .collect(Collectors.toUnmodifiableSet()));
     }
 


### PR DESCRIPTION
take a parent module that has the following configuration and only has changes on test files:
```
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-jar-plugin</artifactId>
                <version>3.2.0</version>
                <executions>
                    <execution>
                        <goals>
                            <goal>test-jar</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```

then following error appears on execution:
```
[ERROR] Failed to execute gitflow-incremental-builder. Cannot invoke "org.codehaus.plexus.util.xml.Xpp3Dom.getChild(String)" because "d" is null -> [Help 1]
```

this PR handles the possible null case of no existing `configuration` property in the `maven-jar-plugin` `test-jar`-goal