### PR TITLE
Update stCarolas/setup-maven from v4 to v4.5

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,7 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4
+      uses: stCarolas/setup-maven@v4.5
       with:
         maven-version: 3.8.7
     - name: Cache Maven Repository
@@ -136,7 +136,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java-maven.java-version }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4
+      uses: stCarolas/setup-maven@v4.5
       with:
         maven-version: ${{ matrix.java-maven.maven-version }}
     - name: Print Java & Maven version


### PR DESCRIPTION
Fixes workflow warnings:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: stCarolas/setup-maven@v4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

v4 is not a floating tag: https://github.com/stCarolas/setup-maven/issues/30#issuecomment-1370542252