### PR TITLE
Revert "Switch to plexus-xml 4.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.slf4j>1.7.36</version.slf4j>   <!-- must match the version that is provided by maven -->
         <version.logback>1.2.12</version.logback>    <!-- the latest that appears to work properly with above slf4j version -->
         <version.javax.inject>1</version.javax.inject>
-        <version.plexus-xml>4.0.0</version.plexus-xml>
+        <version.plexus-utils>3.5.1</version.plexus-utils>
         <version.bytebuddy>1.14.5</version.bytebuddy>
         <version.junit>5.10.0</version.junit>
         <version.archunit>1.0.1</version.archunit>
@@ -170,8 +170,8 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-xml</artifactId>
-            <version>${version.plexus-xml}</version>
+            <artifactId>plexus-utils</artifactId>
+            <version>${version.plexus-utils}</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
This reverts commit e4ded0e834d66fb9eb0bf947f887ad46cdb12688.

4.0.2 brings back the dreaded plexus-utils 1.1 issue for Maven 3.8.