### PR TITLE
Make sure parent directory for `gib.logImpactedTo` exists

### DIFF
--- a/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
@@ -206,6 +206,11 @@ class UnchangedProjectsRemover {
         }
         logger.debug("Writing impacted projects to {}: {}", logFilePath, projectsToLog);
         try {
+            Path parentDir = logFilePath.toAbsolutePath().getParent();
+            // Check if the parent Directory to the logFilePath exists. If not create it.
+            if (parentDir != null && !Files.exists(parentDir)) {
+                Files.createDirectories(parentDir);
+            }
             Files.write(logFilePath, projectsToLog, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to write impacted projects to " + logFilePath + ": " + impacted, e);

--- a/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
@@ -49,7 +49,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertLogFileContains();
+        assertLogFileContains(logFilePath);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertLogFileContains(changedModuleMock);
+        assertLogFileContains(logFilePath, changedModuleMock);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertLogFileContains(changedModuleMock, dependentModuleMock);
+        assertLogFileContains(logFilePath, changedModuleMock, dependentModuleMock);
     }
 
     @Test
@@ -84,10 +84,26 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertLogFileContains(changedModuleMock);
+        assertLogFileContains(logFilePath, changedModuleMock);
     }
 
-    private void assertLogFileContains(MavenProject... mavenProjects) throws IOException {
+    @Test
+    public void logImpactedNonExistingPath() throws IOException {
+        Path nonExistingPath = Path.of("some", "unknown", "path", "impacted.log");
+        Path customLogFilePath = tempDir.resolve(nonExistingPath);
+        assertThat(!Files.exists(customLogFilePath));
+
+        addGibProperty(Property.logImpactedTo, customLogFilePath.toAbsolutePath().toString());
+
+        MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
+
+        underTest.act(config());
+
+        assertThat(Files.exists(customLogFilePath));
+        assertLogFileContains(customLogFilePath, changedModuleMock);
+    }
+
+    private void assertLogFileContains(Path logFilePath, MavenProject... mavenProjects) throws IOException {
         assertThat(Files.isReadable(logFilePath))
                 .as(logFilePath + " is missing")
                 .isTrue();


### PR DESCRIPTION
Noticed during development, The gib.logImpactedTo propertie does not work if the folder to save the log does not exist yet. Add a Check to test the parent folder of the Location and Create and directories if necessary. Add Catch  for SecurityException since it is possible creating directories or files could run into.

---

Respin of #708