### PR TITLE
Fix arbitrary file access during archive extraction ("Zip Slip") in test UnZipper

### DIFF
--- a/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
@@ -41,7 +41,7 @@ public class UnZipper {
         while(ze != null) {
             String fileName = ze.getName();
             // Prevent Zip Slip / directory traversal by ensuring the target path stays within outputFolder
-            Path newFile = normalizedOutputFolder.resolve(fileName).toAbsolutePath().normalize();
+            Path newFile = normalizedOutputFolder.resolve(fileName).normalize();
             if (!newFile.startsWith(normalizedOutputFolder)) {
                 throw new IOException("Bad zip entry: " + fileName);
             }

--- a/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
@@ -40,6 +40,14 @@ public class UnZipper {
         while(ze != null) {
             String fileName = ze.getName();
             Path newFile = outputFolder.resolve(fileName);
+
+            // Prevent Zip Slip / directory traversal by ensuring the target path stays within outputFolder
+            Path normalizedOutput = outputFolder.toAbsolutePath().normalize();
+            Path normalizedNewFile = newFile.toAbsolutePath().normalize();
+            if (!normalizedNewFile.startsWith(normalizedOutput)) {
+                throw new IOException("Bad zip entry: " + fileName);
+            }
+
             createParentDirectories(newFile);
             if (ze.isDirectory()) {
                 Files.createDirectory(newFile);

--- a/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/mocks/UnZipper.java
@@ -37,14 +37,12 @@ public class UnZipper {
 
     private void process(Path outputFolder, ZipInputStream zis) throws IOException {
         ZipEntry ze = zis.getNextEntry();
+        Path normalizedOutputFolder = outputFolder.toAbsolutePath().normalize();
         while(ze != null) {
             String fileName = ze.getName();
-            Path newFile = outputFolder.resolve(fileName);
-
             // Prevent Zip Slip / directory traversal by ensuring the target path stays within outputFolder
-            Path normalizedOutput = outputFolder.toAbsolutePath().normalize();
-            Path normalizedNewFile = newFile.toAbsolutePath().normalize();
-            if (!normalizedNewFile.startsWith(normalizedOutput)) {
+            Path newFile = normalizedOutputFolder.resolve(fileName).toAbsolutePath().normalize();
+            if (!newFile.startsWith(normalizedOutputFolder)) {
                 throw new IOException("Bad zip entry: " + fileName);
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/security/code-scanning/3](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/security/code-scanning/3)

In general, to fix Zip Slip issues you must validate each archive entry’s path before using it for file operations. The standard pattern is: resolve the entry’s name against the destination directory, normalize the result (or get its canonical path), and verify that the normalized path still lies under the intended destination directory. If it does not, reject the entry.

For this specific `UnZipper` class, the best minimal-impact fix is:

1. After computing `newFile = outputFolder.resolve(fileName)`, normalize and check that `newFile` starts with `outputFolder.normalize()`. If not, throw an exception (or skip the entry). This prevents `..` traversal and absolute-path tricks.
2. Base all subsequent operations (creating parent directories, directories, files, timestamps) on this validated `newFile`.
3. Implement the check using existing `java.nio.file.Path` methods, which are already imported (`Path`, `Paths`, `Files`), so no new dependencies are needed.
4. Optionally encapsulate the check in a small private helper method to keep `process` readable, but this is not strictly necessary; an inline check suffices and keeps changes minimal.

Concretely:

- In `process(...)`, after line 42 where `newFile` is assigned, insert a validation block:

  ```java
  Path normalizedOutput = outputFolder.toAbsolutePath().normalize();
  Path normalizedNewFile = newFile.toAbsolutePath().normalize();
  if (!normalizedNewFile.startsWith(normalizedOutput)) {
      throw new IOException("Bad zip entry: " + fileName);
  }
  ```

- Continue using `newFile` for operations. Since `newFile` resolves against `outputFolder`, and we’ve ensured the normalized result is within `outputFolder`, these operations are now safe.

No other methods need to change; the validation will cover all three CodeQL variants, because they all use the same `newFile` path (and its parent) that is now constrained to be under `outputFolder`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
