### PR TITLE
Add workflow permission

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,9 @@ on:
         required: true
         default: 'no'
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Djansi.passthrough=true -XX:TieredStopAtLevel=1
   MVN_DEFAULT_ARGS: -e -B -Dstyle.color=always


### PR DESCRIPTION
Potential fix for [https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/security/code-scanning/1](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal access needed. This can be added at the workflow root (applies to all jobs) or per job. Since both `primary` and `secondary` jobs only need to read repository contents (for checkout) and do not modify repository data, the safest minimal permissions are `contents: read`. Other actions used (`cache`, `upload-artifact`) do not require elevated repository permissions.

The single best fix with no behavior change is to add a workflow‑level `permissions` block right after the `on:` section (or before `env:`) in `.github/workflows/maven.yml`:

```yaml
permissions:
  contents: read
```

This ensures both `primary` and `secondary` jobs run with a read-only token for repository contents, matching their actual needs. No other code, steps, or actions need to be changed, and no additional imports or methods are required.

Concretely:
- File: `.github/workflows/maven.yml`
- Insert a `permissions:` section at the top workflow level, between the triggers (`on:`) and `env:` (for clarity), while preserving indentation (2 spaces for YAML mappings).
- No other regions or files need modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
