### PR TITLE
Add logImpactedGavTo property for independent GAV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
   - [gib.failOnMissingGitDir](#failonmissinggitdir)
   - [gib.failOnError](#gibfailonerror)
   - [gib.logImpactedTo](#giblogimpactedto)
-  - [gib.logImpactedFormat](#giblogimpactedformat)
+  - [gib.logImpactedGavTo](#giblogimpactedgavto)
   - [gib.loadImpactedDependenciesFrom](#gibloadimpacteddependenciesfrom)
   - [gib.logProjectsMode](#giblogprojectsmode)
 
@@ -366,7 +366,7 @@ Maven pom properties configuration with default values is below:
     <gib.failOnMissingGitDir>true</gib.failOnMissingGitDir>                            <!-- or -Dgib.fomgd=... -->
     <gib.failOnError>true</gib.failOnError>                                            <!-- or -Dgib.foe=...   -->
     <gib.logImpactedTo></gib.logImpactedTo>                                            <!-- or -Dgib.lit=...   -->
-    <gib.logImpactedFormat>path</gib.logImpactedFormat>                                <!-- or -Dgib.lif=...   -->
+    <gib.logImpactedGavTo></gib.logImpactedGavTo>                                      <!-- or -Dgib.ligt=...  -->
     <gib.loadImpactedDependenciesFrom></gib.loadImpactedDependenciesFrom>              <!-- or -Dgib.lidf=...  -->
     <gib.logProjectsMode>changed</gib.logProjectsMode>                                 <!-- or -Dgib.lpm=...   -->
 </properties>
@@ -683,7 +683,7 @@ Controls whether or not to fail on any error.
 
 ### gib.logImpactedTo
 
-Defines an optional logfile which GIB shall write all "impacted" modules to. Each line represents the base directory of a changed module
+Defines an optional logfile which GIB shall write all "impacted" module paths to. Each line represents the relative base directory path of a changed module
 or a downstream module of a changed module.
 
 GIB overwrites the file if it already exists and will create an empty file in case no changes are detected.
@@ -700,16 +700,14 @@ Starting with 4.5.0, GIB will always remove the file first (unless disabled via 
 
 Since: 3.10.1
 
-### gib.logImpactedFormat
+### gib.logImpactedGavTo
 
-Controls the output format of the logfile defined by [gib.logImpactedTo](#giblogimpactedto):
+Defines an optional logfile which GIB shall write all "impacted" module GAVs (`GroupId:ArtifactId:Version`) to, one per line.
+Can be used independently of or together with [gib.logImpactedTo](#giblogimpactedto).
 
-- `path` (default): each line contains the relative base directory path of an impacted module
-- `gav`: each line contains the full Maven coordinates (`GroupId:ArtifactId:Version`) of an impacted module
+The same file handling behaviour as [gib.logImpactedTo](#giblogimpactedto) applies (overwrite, empty file on no changes, cleanup on skip, etc.).
 
-This property has no effect if `gib.logImpactedTo` is not set.
-
-Since: 4.6.0
+Since: 4.7.0
 
 ### gib.loadImpactedDependenciesFrom
 

--- a/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import io.github.gitflowincrementalbuilder.config.Configuration;
 import io.github.gitflowincrementalbuilder.config.Configuration.BuildUpstreamMode;
-import io.github.gitflowincrementalbuilder.config.Configuration.LogImpactedFormat;
 import io.github.gitflowincrementalbuilder.config.Configuration.LogProjectsMode;
 import io.github.gitflowincrementalbuilder.jgit.GitProvider;
 
@@ -70,14 +69,9 @@ class UnchangedProjectsRemover {
 
     private void doAct(Configuration config) {
         LazyMavenProjectComparator projectComparator = new LazyMavenProjectComparator(config.mavenSession);
-        // remove a possibly existing logfile of a previous run (so that e.g. SkipExecutionException doesn't leave behind an empty file like in < 4.5.0)
-        config.logImpactedTo.ifPresent(logFilePath -> {
-            try {
-                Files.deleteIfExists(logFilePath);
-            } catch (IOException e) {
-                logger.warn("Could not delete '" + logFilePath + "', file might contain outdated projects!", e);
-            }
-        });
+        // remove possibly existing logfiles of a previous run (so that e.g. SkipExecutionException doesn't leave behind an empty file like in < 4.5.0)
+        deleteLogFileIfExists(config.logImpactedTo);
+        deleteLogFileIfExists(config.logImpactedGavTo);
 
         final Set<MavenProject> selected;
         if (config.disableSelectedProjectsHandling) {
@@ -90,7 +84,7 @@ class UnchangedProjectsRemover {
                 printDelimiter();
                 logger.info("Building explicitly selected projects (without any adjustment): {}",
                         config.mavenSession.getProjects().stream().map(MavenProject::getArtifactId).collect(Collectors.joining(", ")));
-                config.logImpactedTo.ifPresent(logFilePath -> writeImpactedLogFile(selected, logFilePath, projectComparator, config));
+                writeImpactedLogFiles(selected, projectComparator, config);
                 return;
             }
 
@@ -101,7 +95,7 @@ class UnchangedProjectsRemover {
             if (!config.mavenSession.getRequest().isRecursive() || onlySingleLeafModulePresent(config)) {
                 printDelimiter();
                 logger.info("Building single project (without any adjustment): {}", config.currentProject.getArtifactId());
-                config.logImpactedTo.ifPresent(logFilePath -> writeImpactedLogFile(Set.of(config.currentProject), logFilePath, projectComparator, config));
+                writeImpactedLogFiles(Set.of(config.currentProject), projectComparator, config);
                 return;
             }
         }
@@ -119,7 +113,7 @@ class UnchangedProjectsRemover {
         printDelimiter();
         if (changed.isEmpty()) {
             handleNoChangesDetected(selected, projectComparator, config);
-            config.logImpactedTo.ifPresent(logFilePath -> writeImpactedLogFile(Collections.emptySet(), logFilePath, projectComparator, config));
+            writeImpactedLogFiles(Collections.emptySet(), projectComparator, config);
             return;
         }
 
@@ -130,7 +124,7 @@ class UnchangedProjectsRemover {
             lazyDownstreamProjects.get().forEach(proj -> config.argsForDownstreamModules.forEach(proj.getProperties()::setProperty));
         }
 
-        config.logImpactedTo.ifPresent(logFilePath -> writeImpactedLogFile(impacted, logFilePath, projectComparator, config));
+        writeImpactedLogFiles(impacted, projectComparator, config);
 
         LazyValue<List<MavenProject>> lazyUpstreamProjects = new LazyValue<>(
                 () -> config.mavenSession.getProjects().stream().filter(not(impacted::contains)).collect(toList()));
@@ -214,35 +208,46 @@ class UnchangedProjectsRemover {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    private void writeImpactedLogFile(Set<MavenProject> impacted, Path logFilePath, LazyMavenProjectComparator projectComparator,
-            Configuration config) {
-        LogImpactedFormat format = config.logImpactedFormat;
-        List<String> projectsToLog;
-        if (impacted.isEmpty()) {
-            projectsToLog = Collections.emptyList();
-        } else {
-            if (format == LogImpactedFormat.GAV) {
-                projectsToLog = impacted.stream()
-                        .sorted(projectComparator)
-                        .map(proj -> proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion())
-                        .collect(toList());
-            } else {
-                Path projectRootDir = gitProvider.getProjectRoot(config);
-                projectsToLog = impacted.stream()
-                        .sorted(projectComparator)
-                        .map(proj -> projectRootDir.relativize(proj.getBasedir().toPath()).toString())
-                        .collect(toList());
+    private void deleteLogFileIfExists(Optional<Path> logFilePath) {
+        logFilePath.ifPresent(path -> {
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException e) {
+                logger.warn("Could not delete '" + path + "', file might contain outdated projects!", e);
             }
-        }
-        String label = format == LogImpactedFormat.GAV ? "GAVs" : "projects";
-        logger.debug("Writing impacted {} to {}: {}", label, logFilePath, projectsToLog);
+        });
+    }
+
+    private void writeImpactedLogFiles(Set<MavenProject> impacted, LazyMavenProjectComparator projectComparator, Configuration config) {
+        config.logImpactedTo.ifPresent(logFilePath -> {
+            Path projectRootDir = gitProvider.getProjectRoot(config);
+            List<String> projectsToLog = impacted.isEmpty()
+                    ? Collections.emptyList()
+                    : impacted.stream()
+                            .sorted(projectComparator)
+                            .map(proj -> projectRootDir.relativize(proj.getBasedir().toPath()).toString())
+                            .collect(toList());
+            writeLogFile(logFilePath, projectsToLog, "projects", impacted);
+        });
+        config.logImpactedGavTo.ifPresent(logFilePath -> {
+            List<String> gavsToLog = impacted.isEmpty()
+                    ? Collections.emptyList()
+                    : impacted.stream()
+                            .sorted(projectComparator)
+                            .map(proj -> proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion())
+                            .collect(toList());
+            writeLogFile(logFilePath, gavsToLog, "GAVs", impacted);
+        });
+    }
+
+    private void writeLogFile(Path logFilePath, List<String> lines, String label, Set<MavenProject> impacted) {
+        logger.debug("Writing impacted {} to {}: {}", label, logFilePath, lines);
         try {
             Path parentDir = logFilePath.toAbsolutePath().getParent();
-            // Check if the parent Directory to the logFilePath exists. If not create it.
             if (parentDir != null && !Files.exists(parentDir)) {
                 Files.createDirectories(parentDir);
             }
-            Files.write(logFilePath, projectsToLog, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+            Files.write(logFilePath, lines, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to write impacted " + label + " to " + logFilePath + ": " + impacted, e);
         }

--- a/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
@@ -227,7 +227,7 @@ class UnchangedProjectsRemover {
                             .sorted(projectComparator)
                             .map(proj -> projectRootDir.relativize(proj.getBasedir().toPath()).toString())
                             .collect(toList());
-            writeLogFile(logFilePath, projectsToLog, "projects", impacted);
+            writeLogFile(logFilePath, projectsToLog, "project paths", impacted);
         });
         config.logImpactedGavTo.ifPresent(logFilePath -> {
             List<String> gavsToLog = impacted.isEmpty()
@@ -236,7 +236,7 @@ class UnchangedProjectsRemover {
                             .sorted(projectComparator)
                             .map(proj -> proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion())
                             .collect(toList());
-            writeLogFile(logFilePath, gavsToLog, "GAVs", impacted);
+            writeLogFile(logFilePath, gavsToLog, "project GAVs", impacted);
         });
     }
 
@@ -247,7 +247,7 @@ class UnchangedProjectsRemover {
             if (parentDir != null && !Files.exists(parentDir)) {
                 Files.createDirectories(parentDir);
             }
-            Files.write(logFilePath, lines, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+            Files.write(logFilePath, lines, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to write impacted " + label + " to " + logFilePath + ": " + impacted, e);
         }

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
@@ -200,8 +200,13 @@ public class Configuration {
         failOnError = Boolean.parseBoolean(Property.failOnError.getValue(pluginProperties, projectProperties));
 
         // log related
-        logImpactedTo = Property.logImpactedTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
-        logImpactedGavTo = Property.logImpactedGavTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
+        var deprecatedLogImpactedFormatIsGav =
+                parseEnum(Property.logImpactedFormat, LogImpactedFormat.class, pluginProperties, projectProperties) == LogImpactedFormat.GAV;
+        var logImpactedTo = Property.logImpactedTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
+        var logImpactedGavTo = Property.logImpactedGavTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
+        this.logImpactedTo = deprecatedLogImpactedFormatIsGav ? Optional.empty() : logImpactedTo;
+        this.logImpactedGavTo = logImpactedGavTo.or(() -> deprecatedLogImpactedFormatIsGav ? logImpactedTo : Optional.empty());
+
         impactedDependenciesFrom = Property.loadImpactedDependenciesFrom.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
         logProjectsMode = //parseLogProjectsMode(session, pluginProperties, projectProperties);
                 parseEnum(Property.logProjectsMode, LogProjectsMode.class, pluginProperties, projectProperties);
@@ -339,4 +344,8 @@ public class Configuration {
         ALL
     }
 
+    private enum LogImpactedFormat {
+        PATH,
+        GAV
+    }
 }

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
@@ -72,7 +72,7 @@ public class Configuration {
     public final boolean failOnError;
 
     public final Optional<Path> logImpactedTo;
-    public final LogImpactedFormat logImpactedFormat;
+    public final Optional<Path> logImpactedGavTo;
     public final Optional<Path> impactedDependenciesFrom;
     public final LogProjectsMode logProjectsMode;
 
@@ -132,7 +132,7 @@ public class Configuration {
 
             // log related
             logImpactedTo = null;
-            logImpactedFormat = null;
+            logImpactedGavTo = null;
             impactedDependenciesFrom = null;
             logProjectsMode = null;
 
@@ -201,7 +201,7 @@ public class Configuration {
 
         // log related
         logImpactedTo = Property.logImpactedTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
-        logImpactedFormat = parseEnum(Property.logImpactedFormat, LogImpactedFormat.class, pluginProperties, projectProperties);
+        logImpactedGavTo = Property.logImpactedGavTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
         impactedDependenciesFrom = Property.loadImpactedDependenciesFrom.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
         logProjectsMode = //parseLogProjectsMode(session, pluginProperties, projectProperties);
                 parseEnum(Property.logProjectsMode, LogProjectsMode.class, pluginProperties, projectProperties);
@@ -339,8 +339,4 @@ public class Configuration {
         ALL
     }
 
-    public enum LogImpactedFormat {
-        PATH,
-        GAV
-    }
 }

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
@@ -140,13 +140,13 @@ public enum Property {
     failOnError("true", "foe", true),
 
     /**
-     * Defines an optional logfile which GIB shall write all "impacted" modules to.
+     * Defines an optional logfile which GIB shall write all "impacted" module paths to.
      */
     logImpactedTo("", "lit"),
     /**
-     * Controls the output format of the logfile defined by {@link #logImpactedTo}: {@code path} (default) for relative module paths or {@code gav} for GroupId:ArtifactId:Version.
+     * Defines an optional logfile which GIB shall write all "impacted" module GAVs (GroupId:ArtifactId:Version) to.
      */
-    logImpactedFormat("path", "lif"),
+    logImpactedGavTo("", "ligt"),
     /**
      * Defines an optional file containing GAVs of dependencies (one per line) to determine which modules should be built based on transitive dependencies.
      */

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
@@ -144,6 +144,17 @@ public enum Property {
      */
     logImpactedTo("", "lit"),
     /**
+     * Controls the output format of the logfile defined by {@link #logImpactedTo}: {@code path} (default) for relative module paths or {@code gav} for GroupId:ArtifactId:Version.
+     * @deprecated Use {@link #logImpactedGavTo} (or {@link #logImpactedTo}) instead.
+     */
+    @Deprecated
+    logImpactedFormat("path", "lif") {
+        @Override
+        public Optional<Property> getPropertyToMigrateTo(String value) {
+            return logImpactedFormat.getDefaultValue().equalsIgnoreCase(value) ? Optional.of(logImpactedTo) : Optional.of(logImpactedGavTo);
+        }
+    },
+    /**
      * Defines an optional logfile which GIB shall write all "impacted" module GAVs (GroupId:ArtifactId:Version) to.
      */
     logImpactedGavTo("", "ligt"),
@@ -228,14 +239,10 @@ public enum Property {
     }
 
     public ValueWithOriginContext getValueWithOriginContext(Properties pluginProperties, Properties projectProperties) {
-        Optional<ValueWithOriginContext> valueWithName = getValueWithOriginContext(nameCandidatesForPluginProperties, pluginProperties, "plugin");
-        if (!valueWithName.isPresent()) {
-            valueWithName = getValueWithOriginContext(nameCandidatesForSystemProperties, System.getProperties(), "system");
-        }
-        if (!valueWithName.isPresent()) {
-            valueWithName = getValueWithOriginContext(nameCandidatesForProjectProperties, projectProperties, "project");
-        }
-        ValueWithOriginContext finalValueWithOriginContext = valueWithName.orElseGet(() -> new ValueWithOriginContext(defaultValue, name(), "default"));
+        ValueWithOriginContext finalValueWithOriginContext = getValueWithOriginContext(nameCandidatesForPluginProperties, pluginProperties, "plugin")
+                .or(() -> getValueWithOriginContext(nameCandidatesForSystemProperties, System.getProperties(), "system"))
+                .or(() -> getValueWithOriginContext(nameCandidatesForProjectProperties, projectProperties, "project"))
+                .orElseGet(() -> new ValueWithOriginContext(defaultValue, name(), "default"));
         LOGGER.debug("{}", finalValueWithOriginContext);
         return finalValueWithOriginContext;
     }
@@ -257,7 +264,7 @@ public enum Property {
         return defaultValue.equals("true") || defaultValue.equals("false");
     }
 
-    protected Optional<Property> getPropertyToMigrateTo() {
+    protected Optional<Property> getPropertyToMigrateTo(String value) {
         return Optional.empty();
     }
 
@@ -273,19 +280,21 @@ public enum Property {
         if (value == null) {
             return null;
         }
+        if (mapEmptyValueToTrue && value.isEmpty()) {
+            value = "true";
+        }
+
         boolean prefixed = name.startsWith(PREFIX);
         String deprecatedName = prefixed ? deprecatedPrefixedName() : deprecatedName().orElse(null);
         if (name.equals(deprecatedName)) {
             LOGGER.warn("'{}' has been renamed to '{}' and the old name will be removed in an upcoming release. Please adjust your configuration!",
                     deprecatedName, prefixed ? prefixedName : name());
         }
-        getPropertyToMigrateTo().ifPresent(prop -> LOGGER.warn("'{}' is deprecated and will be removed in an upcoming release. Please migrate to '{}'!", name,
+        getPropertyToMigrateTo(value).ifPresent(prop -> LOGGER.warn("'{}' is deprecated and will be removed in an upcoming release. Please migrate to '{}'!", name,
                 prefixed
                         ? prop.prefixedName + (name.equals(prefixedShortName) ? " (" + prop.prefixedShortName + ")" : "")
                         : prop.name()));
-        if (mapEmptyValueToTrue && value.isEmpty()) {
-            value = "true";
-        }
+
         return new ValueWithOriginContext(value, name, propertiesDesc);
     }
 

--- a/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
@@ -9,9 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
@@ -126,7 +126,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
     public void logImpactedNonExistingPath() throws IOException {
         Path nonExistingPath = Path.of("some", "unknown", "path", "impacted.log");
         Path customLogFilePath = tempDir.resolve(nonExistingPath);
-        assertThat(!Files.exists(customLogFilePath));
+        assertThat(customLogFilePath).doesNotExist();
 
         addGibProperty(Property.logImpactedTo, customLogFilePath.toAbsolutePath().toString());
 
@@ -134,7 +134,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertThat(Files.exists(customLogFilePath));
+        assertThat(customLogFilePath).exists();
         assertPathLogFileContains(customLogFilePath, changedModuleMock);
     }
 
@@ -237,7 +237,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
         public void nonExistingPath() throws IOException {
             Path nonExistingPath = Path.of("some", "unknown", "path", "impacted-gavs.log");
             Path customGavLogFilePath = tempDir.resolve(nonExistingPath);
-            assertThat(!Files.exists(customGavLogFilePath));
+            assertThat(customGavLogFilePath).doesNotExist();
 
             addGibProperty(Property.logImpactedGavTo, customGavLogFilePath.toAbsolutePath().toString());
 
@@ -245,7 +245,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
             underTest.act(config());
 
-            assertThat(Files.exists(customGavLogFilePath));
+            assertThat(customGavLogFilePath).exists();
             assertGavLogFileContains(customGavLogFilePath, changedModuleMock);
         }
     }

--- a/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemoverLogImpactedTest.java
@@ -9,24 +9,25 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 
 import io.github.gitflowincrementalbuilder.config.Configuration;
-import io.github.gitflowincrementalbuilder.config.Configuration.LogImpactedFormat;
 import io.github.gitflowincrementalbuilder.config.Property;
 import io.github.gitflowincrementalbuilder.jgit.GitProvider;
 
 /**
- * Tests {@link UnchangedProjectsRemover} with Mockito mocks in context of {@link Property#logImpactedTo}.
+ * Tests {@link UnchangedProjectsRemover} with Mockito mocks in context of {@link Property#logImpactedTo}
+ * and {@link Property#logImpactedGavTo}.
  */
 public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjectsRemoverTest {
 
@@ -46,32 +47,26 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
         when(gitProviderMock.getProjectRoot(any(Configuration.class))).thenReturn(PSEUDO_PROJECT_ROOT);
     }
 
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void logImpatcedTo_nothingChanged(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void nothingChanged() throws IOException {
         addModuleMock(AID_MODULE_B, false);
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format);
+        assertPathLogFileContains(logFilePath);
     }
 
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void singleChanged(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void singleChanged() throws IOException {
         MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format, changedModuleMock);
+        assertPathLogFileContains(logFilePath, changedModuleMock);
     }
 
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void singleChanged_withDownstream(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void singleChanged_withDownstream() throws IOException {
         MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
         MavenProject dependentModuleMock = addModuleMock(AID_MODULE_C, false);
         MavenProject independentModuleMock = addModuleMock(AID_MODULE_D, false);
@@ -82,20 +77,18 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format, changedModuleMock, dependentModuleMock);
+        assertPathLogFileContains(logFilePath, changedModuleMock, dependentModuleMock);
     }
 
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void singleChanged_buildUpstream(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void singleChanged_buildUpstream() throws IOException {
         MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
 
         addGibProperty(Property.buildUpstream, "true");
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format, changedModuleMock);
+        assertPathLogFileContains(logFilePath, changedModuleMock);
     }
 
     @Test
@@ -110,30 +103,25 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
         assertThat(logFilePath).doesNotExist();
     }
 
-
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void onlySelectedModulesPresent(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void onlySelectedModulesPresent() throws IOException {
         addModuleMock(AID_MODULE_B, true);
         setProjectSelections(moduleA);
         overrideProjects(moduleA);
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format, moduleA);
+        assertPathLogFileContains(logFilePath, moduleA);
     }
 
-    @ParameterizedTest
-    @EnumSource(LogImpactedFormat.class)
-    public void nonRecursive(LogImpactedFormat format) throws IOException {
-        addGibProperty(Property.logImpactedFormat, format.name().toLowerCase());
+    @Test
+    public void nonRecursive() throws IOException {
         addModuleMock(AID_MODULE_B, true);
         when(mavenExecutionRequestMock.isRecursive()).thenReturn(false);
 
         underTest.act(config());
 
-        assertLogFileContains(logFilePath, format, moduleA);
+        assertPathLogFileContains(logFilePath, moduleA);
     }
 
     @Test
@@ -149,31 +137,146 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
         underTest.act(config());
 
         assertThat(Files.exists(customLogFilePath));
-        assertLogFileContains(customLogFilePath, LogImpactedFormat.PATH, changedModuleMock);
+        assertPathLogFileContains(customLogFilePath, changedModuleMock);
     }
 
-    private void assertLogFileContains(Path logFilePath, LogImpactedFormat format, MavenProject... mavenProjects) throws IOException {
+    @Nested
+    class LogImpactedGavTo {
+
+        private Path gavLogFilePath;
+
+        @BeforeEach
+        void beforeGav() {
+            gavLogFilePath = tempDir.resolve("impacted-gavs.log");
+            addGibProperty(Property.logImpactedGavTo, gavLogFilePath.toAbsolutePath().toString());
+        }
+
+        @Test
+        public void nothingChanged() throws IOException {
+            addModuleMock(AID_MODULE_B, false);
+
+            underTest.act(config());
+
+            assertPathLogFileContains(logFilePath);
+            assertGavLogFileContains(gavLogFilePath);
+        }
+
+        @Test
+        public void singleChanged() throws IOException {
+            MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
+
+            underTest.act(config());
+
+            assertPathLogFileContains(logFilePath, changedModuleMock);
+            assertGavLogFileContains(gavLogFilePath, changedModuleMock);
+        }
+
+        @Test
+        public void singleChanged_withDownstream() throws IOException {
+            MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
+            MavenProject dependentModuleMock = addModuleMock(AID_MODULE_C, false);
+            MavenProject independentModuleMock = addModuleMock(AID_MODULE_D, false);
+
+            setUpstreamProjects(dependentModuleMock, changedModuleMock, moduleA);
+            setDownstreamProjectsNonTransitive(changedModuleMock, dependentModuleMock);
+            setUpstreamProjects(independentModuleMock, moduleA);
+
+            underTest.act(config());
+
+            assertPathLogFileContains(logFilePath, changedModuleMock, dependentModuleMock);
+            assertGavLogFileContains(gavLogFilePath, changedModuleMock, dependentModuleMock);
+        }
+
+        @Test
+        public void onlySelectedModulesPresent() throws IOException {
+            addModuleMock(AID_MODULE_B, true);
+            setProjectSelections(moduleA);
+            overrideProjects(moduleA);
+
+            underTest.act(config());
+
+            assertPathLogFileContains(logFilePath, moduleA);
+            assertGavLogFileContains(gavLogFilePath, moduleA);
+        }
+
+        @Test
+        public void nonRecursive() throws IOException {
+            addModuleMock(AID_MODULE_B, true);
+            when(mavenExecutionRequestMock.isRecursive()).thenReturn(false);
+
+            underTest.act(config());
+
+            assertPathLogFileContains(logFilePath, moduleA);
+            assertGavLogFileContains(gavLogFilePath, moduleA);
+        }
+
+        @Test
+        public void skipExecutionException() throws IOException {
+            addModuleMock(AID_MODULE_B, true);
+            Files.createFile(logFilePath);
+            Files.createFile(gavLogFilePath);
+            Configuration config = config();
+            when(changedProjectsMock.get(config)).thenThrow(new SkipExecutionException("deliberate test exception"));
+
+            assertThatThrownBy(() -> underTest.act(config)).isInstanceOf(SkipExecutionException.class);
+
+            assertThat(logFilePath).doesNotExist();
+            assertThat(gavLogFilePath).doesNotExist();
+        }
+
+        @Test
+        public void gavOnly() throws IOException {
+            addGibProperty(Property.logImpactedTo, "");
+            MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
+
+            underTest.act(config());
+
+            assertThat(logFilePath).doesNotExist();
+            assertGavLogFileContains(gavLogFilePath, changedModuleMock);
+        }
+
+        @Test
+        public void nonExistingPath() throws IOException {
+            Path nonExistingPath = Path.of("some", "unknown", "path", "impacted-gavs.log");
+            Path customGavLogFilePath = tempDir.resolve(nonExistingPath);
+            assertThat(!Files.exists(customGavLogFilePath));
+
+            addGibProperty(Property.logImpactedGavTo, customGavLogFilePath.toAbsolutePath().toString());
+
+            MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
+
+            underTest.act(config());
+
+            assertThat(Files.exists(customGavLogFilePath));
+            assertGavLogFileContains(customGavLogFilePath, changedModuleMock);
+        }
+    }
+
+    private void assertPathLogFileContains(Path logFilePath, MavenProject... mavenProjects) throws IOException {
         assertThat(Files.isReadable(logFilePath))
                 .as(logFilePath + " is missing")
                 .isTrue();
 
+        List<String> expected = Arrays.stream(mavenProjects)
+                .map(proj -> proj.getBasedir().getName())
+                .collect(Collectors.toList());
+
         assertThat(Files.readAllLines(logFilePath))
                 .as("Unexpected content of " + logFilePath)
-                .isEqualTo(formatProjects(format, mavenProjects));
+                .isEqualTo(expected);
     }
 
-    private List<String> formatProjects(LogImpactedFormat format, MavenProject... mavenProjects) {
-        switch (format) {
-            case GAV:
-                return Arrays.stream(mavenProjects)
-                        .map(proj -> proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion())
-                        .collect(Collectors.toList());
-            case PATH:
-                return Arrays.stream(mavenProjects)
-                        .map(proj -> proj.getBasedir().getName())
-                        .collect(Collectors.toList());
-            default:
-                throw new IllegalArgumentException("Unsupported LogImpactedFormat: " + format);
-        }
+    private void assertGavLogFileContains(Path logFilePath, MavenProject... mavenProjects) throws IOException {
+        assertThat(Files.isReadable(logFilePath))
+                .as(logFilePath + " is missing")
+                .isTrue();
+
+        List<String> expected = Arrays.stream(mavenProjects)
+                .map(proj -> proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion())
+                .collect(Collectors.toList());
+
+        assertThat(Files.readAllLines(logFilePath))
+                .as("Unexpected content of " + logFilePath)
+                .isEqualTo(expected);
     }
 }

--- a/src/test/java/io/github/gitflowincrementalbuilder/config/ConfigurationTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/config/ConfigurationTest.java
@@ -503,6 +503,39 @@ public class ConfigurationTest {
         assertThat(configuration.disable).isTrue();
     }
 
+    @Test
+    public void deprecatedLogImpactedFormat_gav() {
+        System.setProperty(Property.logImpactedFormat.prefixedName(), "gav");
+        System.setProperty(Property.logImpactedTo.prefixedName(), "foo.txt");
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertThat(configuration.logImpactedTo).isEmpty();
+        assertThat(configuration.logImpactedGavTo).hasValue(Path.of("foo.txt"));
+    }
+
+    @Test
+    public void deprecatedLogImpactedFormat_path() {
+        System.setProperty(Property.logImpactedFormat.prefixedName(), "path");
+        System.setProperty(Property.logImpactedTo.prefixedName(), "foo.txt");
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertThat(configuration.logImpactedTo).hasValue(Path.of("foo.txt"));
+        assertThat(configuration.logImpactedGavTo).isEmpty();
+    }
+
+    @Test
+    public void deprecatedLogImpactedFormat_notSet() {
+        System.setProperty(Property.logImpactedTo.prefixedName(), "foo1.txt");
+        System.setProperty(Property.logImpactedGavTo.prefixedName(), "foo2.txt");
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertThat(configuration.logImpactedTo).hasValue(Path.of("foo1.txt"));
+        assertThat(configuration.logImpactedGavTo).hasValue(Path.of("foo2.txt"));
+    }
+
     private void mockPluginConfig(String propertyName, String value) {
         Xpp3Dom childConfigMock = mock(Xpp3Dom.class);
         when(childConfigMock.getName()).thenReturn(propertyName);


### PR DESCRIPTION
- Replaces `logImpactedFormat` with a new `logImpactedGavTo` property so that both path and GAV outputs can be produced in a single build run. 
- `logImpactedTo` now always writes relative paths and `logImpactedGavTo` always writes GAVs, each to its own file.
- Fixes #1180 