### PR TITLE
Rebuild ProjectDependencyGraph to operate on projects mutations of other extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
   - [gib.forceBuildModules](#gibforcebuildmodules)
   - [gib.excludeDownstreamModulesPackagedAs](#gibexcludedownstreammodulespackagedas)
   - [gib.disableSelectedProjectsHandling](#gibdisableselectedprojectshandling)
+  - [gib.rebuildProjectDependencyGraphMode](#gibrebuildprojectdependencygraphmode)
   - [gib.failOnMissingGitDir](#failonmissinggitdir)
   - [gib.failOnError](#gibfailonerror)
   - [gib.logImpactedTo](#giblogimpactedto)
@@ -363,6 +364,7 @@ Maven pom properties configuration with default values is below:
     <gib.forceBuildModules></gib.forceBuildModules>                                    <!-- or -Dgib.fbm=...   -->
     <gib.excludeDownstreamModulesPackagedAs></gib.excludeDownstreamModulesPackagedAs>  <!-- or -Dgib.edmpa=... -->
     <gib.disableSelectedProjectsHandling>false</gib.disableSelectedProjectsHandling>   <!-- or -Dgib.dsph=...  -->
+    <gib.rebuildProjectDependencyGraphMode>auto</gib.rebuildProjectDependencyGraphMode><!-- or -Dgib.rpdgm=... -->
     <gib.failOnMissingGitDir>true</gib.failOnMissingGitDir>                            <!-- or -Dgib.fomgd=... -->
     <gib.failOnError>true</gib.failOnError>                                            <!-- or -Dgib.foe=...   -->
     <gib.logImpactedTo></gib.logImpactedTo>                                            <!-- or -Dgib.lit=...   -->
@@ -672,6 +674,23 @@ This can come in handy if you select just one module with `-pl` but you only wan
 if the selected module itself is changed or one of its (non-selected) upstream modules.
 
 Since: 3.12.0
+
+### gib.rebuildProjectDependencyGraphMode
+
+Controls whether or not to rebuild the project dependency graph instead of using the one provided by MavenSession.
+
+This makes sure that GIB is picking up project mutations (especially dependency additions) performed by other extensions _that ran before it_ (if any).
+
+Available modes are:
+
+- `auto` (default value): rebuild and log a hint of how to disable rebuild if it takes more than 1s
+- `on`: rebuild and never log a hint, regardless of how long the rebuild takes
+- `off`: no rebuild (pre 4.7.0 behaviour)
+
+Please note that GIB has been performing a special kind graph rebuild since 4.3.0 to properly calculate downstream modules if e.g. `-pl` is used.<br/>
+This special `allProjects` rebuild is _not_ controlled by this property and GIB will do it as it sees fit.
+
+Since 4.7.0
 
 ### gib.failOnMissingGitDir
 

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pre-it-jar-support</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <attach>false</attach>
+                            <classifier>it-support</classifier>
+                            <includes>
+                                <include>**/AddUpstreamSyntheticProjectParticipant.class</include>
+                                <include>META-INF/sisu/javax.inject.Named</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
                 <executions>
                     <execution>
@@ -715,6 +735,23 @@
                             <file>${project.build.directory}/${project.build.finalName}.${project.packaging}</file>
                             <localRepositoryPath>${gibIntegrationTestRepoLocal}</localRepositoryPath>
                             <pomFile>${project.basedir}/pom.xml</pomFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-it-install-support</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <!-- no "skip" available -->
+                            <file>${project.build.directory}/${project.build.finalName}-it-support.${project.packaging}</file>
+                            <localRepositoryPath>${gibIntegrationTestRepoLocal}</localRepositoryPath>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}-it-support</artifactId>
+                            <packaging>jar</packaging>
+                            <version>${project.version}</version>
+                            <generatePom>true</generatePom>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.gitflow-incremental-builder</groupId>
     <artifactId>gitflow-incremental-builder</artifactId>
-    <version>4.6.1-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A Maven extension for incremental building of multi-module projects when using Git Flow (or Git in general).</description>
     <url>https://github.com/gitflow-incremental-builder/gitflow-incremental-builder</url>

--- a/src/main/java/io/github/gitflowincrementalbuilder/DownstreamCalculator.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/DownstreamCalculator.java
@@ -19,18 +19,15 @@ import javax.inject.Singleton;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
-import org.apache.maven.graph.DefaultProjectDependencyGraph;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.apache.maven.project.DuplicateProjectException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.TypeAwareExpressionEvaluator;
-import org.codehaus.plexus.util.dag.CycleDetectedException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,18 +56,9 @@ class DownstreamCalculator {
                 // The reactor has been trimmed/filtered, most likely because of -pl and so the default ProjectDependencyGraph
                 // will not give us any downstream dependencies for modules that are not part of the trimmed reactor.
                 // Therefore we need to create a separate graph that contains all modules.
-                try {
-                    try {
-                        graph = new DefaultProjectDependencyGraph(allProjects);
-                    } catch (NoClassDefFoundError err) {
-                        // cannot use DPDG in maven < 3.8.8 (https://issues.apache.org/jira/browse/MNG-6972) so use our own copy
-                        graph = new Maven38DefaultDependencyGraph(allProjects);
-                    }
-                } catch (CycleDetectedException | DuplicateProjectException e) {
-                    throw new IllegalStateException(e); // extremely unlikely
-                }
+                graph = ProjectDependencyGraphFactory.createGraph(allProjects, config, true);
             } else {
-                graph = config.mavenSession.getProjectDependencyGraph();
+                graph = config.projectDependencyGraph.get();
             }
         }
         boolean testOnly = ChangedProjects.isTestOnly(project);

--- a/src/main/java/io/github/gitflowincrementalbuilder/LazyValue.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/LazyValue.java
@@ -1,20 +1,25 @@
 package io.github.gitflowincrementalbuilder;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
-class LazyValue<T> implements Supplier<T> {
+/**
+ * A lazy value that is initialized on first access. Not thread-safe and for internal use only.
+ */
+public class LazyValue<T> implements Supplier<T> {
 
     private T value;
-    private final Supplier<T> initializer;
+    private Supplier<T> initializer;
 
     public LazyValue(Supplier<T> initializer) {
-        this.initializer = initializer;
+        this.initializer = Objects.requireNonNull(initializer);
     }
 
     @Override
     public T get() {
-        if (value == null) {
+        if (initializer != null) {
             value = initializer.get();
+            initializer = null;
         }
         return value;
     }

--- a/src/main/java/io/github/gitflowincrementalbuilder/MavenLifecycleParticipant.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/MavenLifecycleParticipant.java
@@ -50,6 +50,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
         }
 
         // check prerequisites
+        // config.projectDependencyGraph is not used here deliberately, because it doesn't make sense to build our own graph if even Maven doesn't provide one
         if (session.getProjectDependencyGraph() == null) {
             logger.warn("Execution of gitflow-incremental-builder is not supported in this environment: "
                     + "Current MavenSession does not provide a ProjectDependencyGraph. "

--- a/src/main/java/io/github/gitflowincrementalbuilder/ProjectDependencyGraphFactory.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/ProjectDependencyGraphFactory.java
@@ -1,0 +1,57 @@
+package io.github.gitflowincrementalbuilder;
+
+import java.util.Collection;
+
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.graph.DefaultProjectDependencyGraph;
+import org.apache.maven.project.DuplicateProjectException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.dag.CycleDetectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.gitflowincrementalbuilder.config.Configuration;
+import io.github.gitflowincrementalbuilder.config.Configuration.RebuildProjectDependencyGraphMode;
+import io.github.gitflowincrementalbuilder.config.Property;
+
+public class ProjectDependencyGraphFactory {
+
+    static final int REBUILD_DURATION_THRESHOLD_MS = 1000;
+
+    private static Logger logger = LoggerFactory.getLogger(ProjectDependencyGraphFactory.class);
+
+    public static ProjectDependencyGraph createGraph(Collection<MavenProject> projects, Configuration config, boolean forceCreation) {
+        if (!forceCreation && config.rebuildProjectDependencyGraphMode == RebuildProjectDependencyGraphMode.OFF) {
+            return config.mavenSession.getProjectDependencyGraph();
+        }
+
+        var start = System.currentTimeMillis();
+        try {
+            try {
+                return new DefaultProjectDependencyGraph(projects);
+            } catch (NoClassDefFoundError err) {
+                // cannot use DPDG in maven < 3.8.8 (https://issues.apache.org/jira/browse/MNG-6972) so use our own copy
+                return new Maven38DefaultDependencyGraph(projects);
+            }
+        } catch (CycleDetectedException | DuplicateProjectException e) {
+            if (forceCreation) {
+                throw new IllegalStateException("Failed to build project dependency graph for allProjects", e);
+            }
+            logger.warn("Failed to rebuild project dependency graph, falling back to session graph. "
+                    + "Projects added or modified by previous extensions will not be picked up!", e);
+            return config.mavenSession.getProjectDependencyGraph();
+        } finally {
+            var duration = System.currentTimeMillis() - start;
+            if (!forceCreation && config.rebuildProjectDependencyGraphMode == RebuildProjectDependencyGraphMode.AUTO
+                    && duration >= REBUILD_DURATION_THRESHOLD_MS) {
+                logger.info("Graph creation for {} projects took {}ms, which is a considerable overhead. "
+                        + "If there are no other Maven extensions in place that add or modify projects, "
+                        + "this rebuild can be switched off via property '{}' to save some time.",
+                        projects.size(), duration, Property.rebuildProjectDependencyGraphMode.prefixedName());
+            } else {
+                logger.debug("Graph creation for {} projects took {}ms", projects.size(), duration);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/UnchangedProjectsRemover.java
@@ -300,7 +300,7 @@ class UnchangedProjectsRemover {
                 throw new IllegalStateException("Unsupported BuildUpstreamMode: " + buildUpstreamMode);
         }
         Set<MavenProject> upstreamProjects = upstreamRequiringProjects.stream()
-                .flatMap(proj -> streamUpstreamProjects(proj, config.mavenSession))
+                .flatMap(proj -> streamUpstreamProjects(proj, config))
                 .filter(not(impacted::contains))
                 .peek(proj -> applyUpstreamModuleArgs(proj, config))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -360,8 +360,8 @@ class UnchangedProjectsRemover {
         logger.info("------------------------------------------------------------------------");
     }
 
-    private Stream<MavenProject> streamUpstreamProjects(MavenProject project, MavenSession mavenSession) {
-        return mavenSession.getProjectDependencyGraph().getUpstreamProjects(project, true).stream();
+    private Stream<MavenProject> streamUpstreamProjects(MavenProject project, Configuration config) {
+        return config.projectDependencyGraph.get().getUpstreamProjects(project, true).stream();
     }
 
     private boolean matchesAny(final String str, Collection<Pattern> patterns) {

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Configuration.java
@@ -24,12 +24,15 @@ import java.util.stream.Stream;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.gitflowincrementalbuilder.LazyValue;
+import io.github.gitflowincrementalbuilder.ProjectDependencyGraphFactory;
 import io.github.gitflowincrementalbuilder.config.Property.ValueWithOriginContext;
 
 public class Configuration {
@@ -38,6 +41,7 @@ public class Configuration {
 
     public final MavenSession mavenSession;
     public final MavenProject currentProject;
+    public final LazyValue<ProjectDependencyGraph> projectDependencyGraph;
 
     public final boolean help;
     public final boolean disable;
@@ -67,6 +71,7 @@ public class Configuration {
     public final Map<Pattern, Pattern> forceBuildModulesConditionally;
     public final List<String> excludeDownstreamModulesPackagedAs;
     public final boolean disableSelectedProjectsHandling;
+    public final RebuildProjectDependencyGraphMode rebuildProjectDependencyGraphMode;
 
     public final boolean failOnMissingGitDir;
     public final boolean failOnError;
@@ -82,6 +87,7 @@ public class Configuration {
     public Configuration(MavenSession session) {
         this.mavenSession = session;
         this.currentProject = findCurrentProject(session);
+        projectDependencyGraph = new LazyValue<>(() -> ProjectDependencyGraphFactory.createGraph(mavenSession.getProjects(), Configuration.this, false));
 
         Properties[] properties = getProperties(currentProject, logger);
         Properties projectProperties = properties[0];
@@ -124,6 +130,7 @@ public class Configuration {
             excludeDownstreamModulesPackagedAs = null;
 
             disableSelectedProjectsHandling = false;
+            rebuildProjectDependencyGraphMode = null;
 
             // error handling config
 
@@ -193,6 +200,8 @@ public class Configuration {
                 .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
         disableSelectedProjectsHandling = Boolean.parseBoolean(Property.disableSelectedProjectsHandling.getValue(pluginProperties, projectProperties));
+        rebuildProjectDependencyGraphMode =
+                parseEnum(Property.rebuildProjectDependencyGraphMode, RebuildProjectDependencyGraphMode.class, pluginProperties, projectProperties);
 
         // error handling config
 
@@ -208,8 +217,7 @@ public class Configuration {
         this.logImpactedGavTo = logImpactedGavTo.or(() -> deprecatedLogImpactedFormatIsGav ? logImpactedTo : Optional.empty());
 
         impactedDependenciesFrom = Property.loadImpactedDependenciesFrom.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
-        logProjectsMode = //parseLogProjectsMode(session, pluginProperties, projectProperties);
-                parseEnum(Property.logProjectsMode, LogProjectsMode.class, pluginProperties, projectProperties);
+        logProjectsMode = parseEnum(Property.logProjectsMode, LogProjectsMode.class, pluginProperties, projectProperties);
     }
 
     /**
@@ -342,6 +350,12 @@ public class Configuration {
         CHANGED,
         IMPACTED,
         ALL
+    }
+
+    public enum RebuildProjectDependencyGraphMode {
+        AUTO,
+        ON,
+        OFF
     }
 
     private enum LogImpactedFormat {

--- a/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
+++ b/src/main/java/io/github/gitflowincrementalbuilder/config/Property.java
@@ -129,6 +129,10 @@ public enum Property {
      * Disables special handling of explicitly selected projects (-pl, -f etc.).
      */
     disableSelectedProjectsHandling("false", "dsph", true),
+    /**
+     * Controls whether or not to rebuild the project dependency graph instead of using the one provided by MavenSession.
+     */
+    rebuildProjectDependencyGraphMode("auto", "rpdgm"),
 
     /**
      * Controls whether or not to fail on missing .git directory.

--- a/src/test/java/io/github/gitflowincrementalbuilder/BaseUnchangedProjectsRemoverTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/BaseUnchangedProjectsRemoverTest.java
@@ -2,7 +2,10 @@ package io.github.gitflowincrementalbuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -27,11 +30,13 @@ import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
@@ -86,6 +91,8 @@ abstract class BaseUnchangedProjectsRemoverTest {
     @InjectMocks
     protected UnchangedProjectsRemover underTest;
 
+    private MockedStatic<ProjectDependencyGraphFactory> mockedStaticGraphFactory;
+
     protected final Set<MavenProject> changedProjects = new LinkedHashSet<>();
 
     /**
@@ -117,11 +124,21 @@ abstract class BaseUnchangedProjectsRemoverTest {
         when(mavenSessionMock.getRequest()).thenReturn(mavenExecutionRequestMock);
         when(mavenSessionMock.getProjects()).thenReturn(projects);
         when(mavenSessionMock.getAllProjects()).thenReturn(allProjects);
-        when(mavenSessionMock.getProjectDependencyGraph()).thenReturn(projectDependencyGraphMock);
         when(changedProjectsMock.get(any(Configuration.class))).thenReturn(changedProjects);
         when(impactedDependencies.get(any(Configuration.class))).thenReturn(changedProjects);
 
         when(mavenSessionMock.getGoals()).thenReturn(new ArrayList<>());
+
+        mockedStaticGraphFactory = mockStatic(ProjectDependencyGraphFactory.class);
+        mockedStaticGraphFactory.when(() -> ProjectDependencyGraphFactory.createGraph(anyCollection(), any(Configuration.class), anyBoolean()))
+                .thenReturn(projectDependencyGraphMock);
+    }
+
+    @AfterEach
+    void after() {
+        if (mockedStaticGraphFactory != null) {
+            mockedStaticGraphFactory.close();
+        }
     }
 
     protected MavenProject addModuleMock(String moduleArtifactId, boolean addToChanged) {

--- a/src/test/java/io/github/gitflowincrementalbuilder/ProjectDependencyGraphFactoryTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/ProjectDependencyGraphFactoryTest.java
@@ -1,0 +1,100 @@
+package io.github.gitflowincrementalbuilder;
+
+import static io.github.gitflowincrementalbuilder.ProjectDependencyGraphFactory.createGraph;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.graph.DefaultProjectDependencyGraph;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.gitflowincrementalbuilder.config.Configuration;
+import io.github.gitflowincrementalbuilder.config.Property;
+import io.github.gitflowincrementalbuilder.util.LoggerSpyUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectDependencyGraphFactoryTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MavenSession mavenSessionMock;
+
+    @Mock
+    private ProjectDependencyGraph sessionGraphMock;
+
+    private final Properties projectProperties = new Properties();
+
+    @BeforeEach
+    void setUp() {
+        var currentProject = mock(MavenProject.class);
+        when(currentProject.getProperties()).thenReturn(projectProperties);
+        when(mavenSessionMock.getCurrentProject()).thenReturn(currentProject);
+        when(mavenSessionMock.getProjectDependencyGraph()).thenReturn(sessionGraphMock);
+    }
+
+    @Test
+    void createGraph_modeOff() {
+        projectProperties.setProperty(Property.rebuildProjectDependencyGraphMode.prefixedName(), "off");
+
+        var result = createGraph(List.of(), new Configuration(mavenSessionMock), false);
+        
+        assertThat(result).isSameAs(sessionGraphMock);
+    }
+
+    @Test
+    void createGraph_modeOff_force() {
+        projectProperties.setProperty(Property.rebuildProjectDependencyGraphMode.prefixedName(), "off");
+
+        var result = createGraph(List.of(), new Configuration(mavenSessionMock), true);
+        
+        assertThat(result)
+                .isExactlyInstanceOf(DefaultProjectDependencyGraph.class)
+                .isNotSameAs(sessionGraphMock);
+    }
+
+    // note: Maven38DefaultDependencyGraph case not testable due to https://github.com/mockito/mockito/issues/3629,
+    //       same for CycleDetectedException and DuplicateProjectException cases, as they are thrown from the constructor
+    
+    @Test
+    void createGraph_slow() throws Exception {
+        // logger spy has to be installed via reflection because the field in the target class is static
+        Logger originalLogger = LoggerFactory.getLogger(ProjectDependencyGraphFactory.class);
+        Field loggerField = FieldUtils.getField(ProjectDependencyGraphFactory.class, "logger", true);
+        Logger loggerSpy = LoggerSpyUtil.buildSpiedLoggerFor(ProjectDependencyGraphFactory.class);
+        FieldUtils.writeStaticField(loggerField, loggerSpy, true);
+
+        try (var mockedConstruction = mockConstruction(DefaultProjectDependencyGraph.class, (mock, context) -> {
+                Thread.sleep(ProjectDependencyGraphFactory.REBUILD_DURATION_THRESHOLD_MS + 1);
+            })) {
+
+            var result = createGraph(List.of(), new Configuration(mavenSessionMock), false);
+
+            assertThat(result)
+                    .isExactlyInstanceOf(DefaultProjectDependencyGraph.class)
+                    .isNotSameAs(sessionGraphMock);
+
+            verify(loggerSpy).info(contains("this rebuild can be switched off via property"), any(Object[].class));
+        } finally {
+            FieldUtils.writeStaticField(loggerField, originalLogger, true);
+        }
+    }
+
+}

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
@@ -2,10 +2,12 @@ package io.github.gitflowincrementalbuilder.integration;
 
 import static java.util.function.Predicate.not;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -92,15 +94,15 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
         model.setPackaging("pom");
 
         // Prepare the directory and files
-        File workDir = new File(session.getExecutionRootDirectory(), "target/it-synthetic-upstream");
+        Path workDir = Paths.get(session.getExecutionRootDirectory(), "target", "it-synthetic-upstream");
         mkdirs(workDir);
-        File pomFile = new File(workDir, "pom.xml");
+        Path pomFile = workDir.resolve("pom.xml");
 
         // Serialize the Model to pom.xml
         MavenXpp3Writer writer = new MavenXpp3Writer();
 
         try {
-            writer.write(Files.newBufferedWriter(pomFile.toPath()), model);
+            writer.write(Files.newBufferedWriter(pomFile), model);
             
             // Install to the local repository so Maven can resolve the dependency
             // This is critical - Maven's dependency resolution looks in the local repo
@@ -111,7 +113,7 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
 
         // Create and return the MavenProject
         MavenProject project = new MavenProject(model);
-        project.setFile(pomFile);
+        project.setFile(pomFile.toFile());
         project.setGroupId(SYNTHETIC_GROUP_ID);
         project.setArtifactId(SYNTHETIC_ARTIFACT_ID);
         project.setVersion(SYNTHETIC_VERSION);
@@ -127,7 +129,7 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
             null,
             new DefaultArtifactHandler("pom")
         );
-        artifact.setFile(pomFile);
+        artifact.setFile(pomFile.toFile());
         artifact.setResolved(true);
         project.setArtifact(artifact);
 
@@ -138,24 +140,26 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
      * Install the POM to the local repository used by integration tests.
      * This mimics what 'mvn install' does, making the artifact available for dependency resolution.
      */
-    private void installToLocalRepository(MavenSession session, File pomFile) throws IOException {
-        File localRepo = session.getRequest().getLocalRepositoryPath();
+    private void installToLocalRepository(MavenSession session, Path pomFile) throws IOException {
+        Path localRepo = session.getRequest().getLocalRepositoryPath().toPath();
 
         // Calculate the local repository path structure: groupId/artifactId/version/
         String groupPath = SYNTHETIC_GROUP_ID.replace('.', '/');
-        File artifactDir = new File(localRepo, groupPath + "/" + SYNTHETIC_ARTIFACT_ID + "/" + SYNTHETIC_VERSION);
+        Path artifactDir = localRepo.resolve(groupPath).resolve(SYNTHETIC_ARTIFACT_ID).resolve(SYNTHETIC_VERSION);
         mkdirs(artifactDir);
         
         // Copy POM file
-        File localRepoPom = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".pom");
-        Files.copy(pomFile.toPath(), localRepoPom.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Path localRepoPom = artifactDir.resolve(SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".pom");
+        Files.copy(pomFile, localRepoPom, StandardCopyOption.REPLACE_EXISTING);
         
         logger.info("Installed synthetic artifact to local repository: {}", localRepoPom);
     }
 
-    private static void mkdirs(File dir) {
-        if (!dir.mkdirs() && !dir.isDirectory()) {
-            throw new IllegalStateException("Failed to create directory: " + dir);
+    private static void mkdirs(Path dir) {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create directory: " + dir, e);
         }
     }
 }

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
@@ -1,0 +1,198 @@
+package io.github.gitflowincrementalbuilder.integration;
+
+import static java.util.function.Predicate.not;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+@Singleton
+public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecycleParticipant {
+
+    // If unset/blank => no-op
+    public static final String PROP_TARGET_ARTIFACT_ID = "it.inject.dep.targetArtifactId";
+
+    private static final String SYNTHETIC_GROUP_ID = "it.synthetic";
+    private static final String SYNTHETIC_ARTIFACT_ID = "added-upstream";
+    private static final String SYNTHETIC_VERSION = "1.0.0-SNAPSHOT";
+    
+    private Logger logger = LoggerFactory.getLogger(AddUpstreamSyntheticProjectParticipant.class);
+
+    @Override
+    public void afterProjectsRead(MavenSession session) {
+        Properties userProps = session.getUserProperties();
+        final String targetArtifactId = Optional.ofNullable(userProps.getProperty(PROP_TARGET_ARTIFACT_ID))
+                .map(String::trim)
+                .filter(not(String::isEmpty))
+                .orElse(null);
+        if (targetArtifactId == null) {
+            return;
+        }
+
+        List<MavenProject> projects = session.getProjects();
+        if (projects == null || projects.isEmpty()) {
+            return;
+        }
+
+        MavenProject target = projects.stream()
+                .filter(p -> targetArtifactId.equals(p.getArtifactId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Target project with artifactId=" + targetArtifactId + " not found in reactor projects"));
+
+        // avoid duplicate synthetic project insertion
+        boolean syntheticExists = projects.stream().anyMatch(p ->
+                SYNTHETIC_GROUP_ID.equals(p.getGroupId())
+                        && SYNTHETIC_ARTIFACT_ID.equals(p.getArtifactId()));
+        if (syntheticExists) {
+            return;
+        }
+
+        // create synthetic project from a programmatically built Model
+        MavenProject synthetic = createSyntheticProject(session);
+
+        // Add synthetic to session first, so it's in the reactor
+        List<MavenProject> mutated = new ArrayList<>(projects);
+        mutated.add(synthetic);
+        session.setProjects(mutated);
+        List<MavenProject> mutatedAll = new ArrayList<>(session.getAllProjects());
+        mutatedAll.add(synthetic);
+        session.setAllProjects(mutatedAll);
+
+        // make target depend on synthetic => synthetic is upstream of target
+        boolean depAlreadyPresent = target.getDependencies().stream().anyMatch(d ->
+                SYNTHETIC_GROUP_ID.equals(d.getGroupId())
+                        && SYNTHETIC_ARTIFACT_ID.equals(d.getArtifactId())
+                        && SYNTHETIC_VERSION.equals(d.getVersion()));
+        if (!depAlreadyPresent) {
+            Dependency dep = new Dependency();
+            dep.setGroupId(SYNTHETIC_GROUP_ID);
+            dep.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+            dep.setVersion(SYNTHETIC_VERSION);
+            // Use jar type instead of pom - even pom-packaged projects can have jar dependencies
+            // and jar dependencies in the reactor don't trigger the same resolution issues
+            dep.setType("jar");
+            dep.setScope("compile");
+            dep.setOptional(true);  // Optional to avoid strict resolution requirements
+            target.getModel().addDependency(dep);
+        }
+
+        logger.info("Added synthetic upstream project {}:{} and injected dependency into target {}:{}",
+                SYNTHETIC_GROUP_ID, SYNTHETIC_ARTIFACT_ID, target.getGroupId(), target.getArtifactId());
+    }
+
+    private MavenProject createSyntheticProject(MavenSession session) {
+        try {
+            // Get the local repository path directly from the Maven request
+            File localRepo = session.getRequest().getLocalRepositoryPath();
+            logger.debug("Local repository: {}", localRepo.getAbsolutePath());
+            
+            // Create the Model programmatically  
+            Model model = new Model();
+            model.setModelVersion("4.0.0");
+            model.setGroupId(SYNTHETIC_GROUP_ID);
+            model.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+            model.setVersion(SYNTHETIC_VERSION);
+            model.setPackaging("jar");  // Use jar packaging so dependency resolution works
+            model.setName("IT Synthetic Upstream Project");
+            
+            // Prepare the directory and files in the local repository
+            File targetDir = new File(localRepo.getParentFile(), "it-synthetic-upstream");
+            targetDir.mkdirs();
+            File pomFile = new File(targetDir, "pom.xml");
+            
+            // Serialize the Model to pom.xml
+            MavenXpp3Writer writer = new MavenXpp3Writer();
+            writer.write(Files.newBufferedWriter(pomFile.toPath()), model);
+            
+            // Create an empty jar file so the artifact can be resolved
+            File jarFile = new File(targetDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
+            createEmptyJarFile(jarFile);
+            
+            // Install to the local repository so Maven can resolve the dependency
+            // This is critical - Maven's dependency resolution looks in the local repo
+            installToLocalRepository(localRepo, pomFile, jarFile);
+            
+            // Create and return the MavenProject
+            MavenProject project = new MavenProject(model);
+            project.setFile(pomFile);
+            project.setGroupId(SYNTHETIC_GROUP_ID);
+            project.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+            project.setVersion(SYNTHETIC_VERSION);
+            project.setPackaging("jar");
+            
+            // Create and set a proper Artifact pointing to the jar file
+            Artifact artifact = new DefaultArtifact(
+                SYNTHETIC_GROUP_ID,
+                SYNTHETIC_ARTIFACT_ID,
+                SYNTHETIC_VERSION,
+                "compile",
+                "jar",
+                null,
+                new DefaultArtifactHandler("jar")
+            );
+            artifact.setFile(jarFile);
+            artifact.setResolved(true);
+            project.setArtifact(artifact);
+            
+            return project;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create synthetic project", e);
+        }
+    }
+    
+    /**
+     * Create an empty jar file so Maven's dependency resolution can find an artifact.
+     */
+    private void createEmptyJarFile(File jarFile) throws IOException {
+        // Create a minimal valid JAR file (which is a ZIP file with a MANIFEST.MF)
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                Files.newOutputStream(jarFile.toPath()), 
+                new java.util.jar.Manifest())) {
+            // Empty jar with just a manifest
+        }
+        logger.debug("Created empty jar file: {}", jarFile);
+    }
+    
+    /**
+     * Install the POM and JAR to the local repository used by integration tests.
+     * This mimics what 'mvn install' does, making the artifact available for dependency resolution.
+     */
+    private void installToLocalRepository(File localRepo, File pomFile, File jarFile) throws IOException {
+        // Calculate the local repository path structure: groupId/artifactId/version/
+        String groupPath = SYNTHETIC_GROUP_ID.replace('.', '/');
+        File artifactDir = new File(localRepo, groupPath + "/" + SYNTHETIC_ARTIFACT_ID + "/" + SYNTHETIC_VERSION);
+        artifactDir.mkdirs();
+        
+        // Copy POM file
+        File localRepoPom = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".pom");
+        Files.copy(pomFile.toPath(), localRepoPom.toPath(), 
+                   java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        
+        // Copy JAR file
+        File localRepoJar = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
+        Files.copy(jarFile.toPath(), localRepoJar.toPath(), 
+                   java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        
+        logger.info("Installed synthetic artifact to local repository: {}", localRepoJar);
+    }
+}

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
@@ -4,6 +4,7 @@ import static java.util.function.Predicate.not;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,9 +73,7 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
         dep.setGroupId(SYNTHETIC_GROUP_ID);
         dep.setArtifactId(SYNTHETIC_ARTIFACT_ID);
         dep.setVersion(SYNTHETIC_VERSION);
-        // Use jar type instead of pom - even pom-packaged projects can have jar dependencies
-        // and jar dependencies in the reactor don't trigger the same resolution issues
-        dep.setType("jar");
+        dep.setType("pom");
         dep.setScope("compile");
         target.getModel().addDependency(dep);
 
@@ -83,79 +82,63 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
     }
 
     private MavenProject createSyntheticProject(MavenSession session) {
-        try {
             
-            // Create the Model programmatically  
-            Model model = new Model();
-            model.setModelVersion("4.0.0");
-            model.setGroupId(SYNTHETIC_GROUP_ID);
-            model.setArtifactId(SYNTHETIC_ARTIFACT_ID);
-            model.setVersion(SYNTHETIC_VERSION);
-            model.setPackaging("jar");
+        // Create the Model
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId(SYNTHETIC_GROUP_ID);
+        model.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+        model.setVersion(SYNTHETIC_VERSION);
+        model.setPackaging("pom");
 
-            // Prepare the directory and files
-            File workDir = new File(session.getExecutionRootDirectory(), "target/it-synthetic-upstream");
-            mkdirs(workDir);
-            File pomFile = new File(workDir, "pom.xml");
-            
-            // Serialize the Model to pom.xml
-            MavenXpp3Writer writer = new MavenXpp3Writer();
+        // Prepare the directory and files
+        File workDir = new File(session.getExecutionRootDirectory(), "target/it-synthetic-upstream");
+        mkdirs(workDir);
+        File pomFile = new File(workDir, "pom.xml");
+
+        // Serialize the Model to pom.xml
+        MavenXpp3Writer writer = new MavenXpp3Writer();
+
+        try {
             writer.write(Files.newBufferedWriter(pomFile.toPath()), model);
-            
-            // Create an empty jar file so the artifact can be resolved
-            File jarFile = new File(workDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
-            createEmptyJarFile(jarFile);
             
             // Install to the local repository so Maven can resolve the dependency
             // This is critical - Maven's dependency resolution looks in the local repo
-            installToLocalRepository(session, pomFile, jarFile);
-            
-            // Create and return the MavenProject
-            MavenProject project = new MavenProject(model);
-            project.setFile(pomFile);
-            project.setGroupId(SYNTHETIC_GROUP_ID);
-            project.setArtifactId(SYNTHETIC_ARTIFACT_ID);
-            project.setVersion(SYNTHETIC_VERSION);
-            project.setPackaging("jar");
-            
-            // Create and set a proper Artifact pointing to the jar file
-            Artifact artifact = new DefaultArtifact(
-                SYNTHETIC_GROUP_ID,
-                SYNTHETIC_ARTIFACT_ID,
-                SYNTHETIC_VERSION,
-                "compile",
-                "jar",
-                null,
-                new DefaultArtifactHandler("jar")
-            );
-            artifact.setFile(jarFile);
-            artifact.setResolved(true);
-            project.setArtifact(artifact);
-            
-            return project;
+            installToLocalRepository(session, pomFile);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create synthetic project", e);
+            throw new UncheckedIOException("Failed to create synthetic project", e);
         }
+
+        // Create and return the MavenProject
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile);
+        project.setGroupId(SYNTHETIC_GROUP_ID);
+        project.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+        project.setVersion(SYNTHETIC_VERSION);
+        project.setPackaging("pom");
+
+        // Create and set a proper Artifact pointing to the pom file
+        Artifact artifact = new DefaultArtifact(
+            SYNTHETIC_GROUP_ID,
+            SYNTHETIC_ARTIFACT_ID,
+            SYNTHETIC_VERSION,
+            "compile",
+            "pom",
+            null,
+            new DefaultArtifactHandler("pom")
+        );
+        artifact.setFile(pomFile);
+        artifact.setResolved(true);
+        project.setArtifact(artifact);
+
+        return project;
     }
     
     /**
-     * Create an empty jar file so Maven's dependency resolution can find an artifact.
-     */
-    private void createEmptyJarFile(File jarFile) throws IOException {
-        // Create a minimal valid JAR file (which is a ZIP file with a MANIFEST.MF)
-        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
-                Files.newOutputStream(jarFile.toPath()), 
-                new java.util.jar.Manifest())) {
-            // Empty jar with just a manifest
-        }
-        logger.debug("Created empty jar file: {}", jarFile);
-    }
-    
-    /**
-     * Install the POM and JAR to the local repository used by integration tests.
+     * Install the POM to the local repository used by integration tests.
      * This mimics what 'mvn install' does, making the artifact available for dependency resolution.
      */
-    private void installToLocalRepository(MavenSession session, File pomFile, File jarFile) throws IOException {
+    private void installToLocalRepository(MavenSession session, File pomFile) throws IOException {
         File localRepo = session.getRequest().getLocalRepositoryPath();
 
         // Calculate the local repository path structure: groupId/artifactId/version/
@@ -167,11 +150,7 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
         File localRepoPom = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".pom");
         Files.copy(pomFile.toPath(), localRepoPom.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
         
-        // Copy JAR file
-        File localRepoJar = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
-        Files.copy(jarFile.toPath(), localRepoJar.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-        
-        logger.info("Installed synthetic artifact to local repository: {}", localRepoJar);
+        logger.info("Installed synthetic artifact to local repository: {}", localRepoPom);
     }
 
     private static void mkdirs(File dir) {

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
@@ -30,11 +30,11 @@ import org.slf4j.LoggerFactory;
 public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecycleParticipant {
 
     // If unset/blank => no-op
-    public static final String PROP_TARGET_ARTIFACT_ID = "it.inject.dep.targetArtifactId";
+    public static final String PROP_TARGET_ARTIFACT_ID = "it.synthetic.dep.targetArtifactId";
 
-    private static final String SYNTHETIC_GROUP_ID = "it.synthetic";
-    private static final String SYNTHETIC_ARTIFACT_ID = "added-upstream";
-    private static final String SYNTHETIC_VERSION = "1.0.0-SNAPSHOT";
+    public static final String SYNTHETIC_GROUP_ID = "it.synthetic";
+    public static final String SYNTHETIC_ARTIFACT_ID = "synthetically-added-upstream";
+    public static final String SYNTHETIC_VERSION = "1.0-SNAPSHOT";
     
     private Logger logger = LoggerFactory.getLogger(AddUpstreamSyntheticProjectParticipant.class);
 
@@ -50,22 +50,11 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
         }
 
         List<MavenProject> projects = session.getProjects();
-        if (projects == null || projects.isEmpty()) {
-            return;
-        }
 
         MavenProject target = projects.stream()
                 .filter(p -> targetArtifactId.equals(p.getArtifactId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Target project with artifactId=" + targetArtifactId + " not found in reactor projects"));
-
-        // avoid duplicate synthetic project insertion
-        boolean syntheticExists = projects.stream().anyMatch(p ->
-                SYNTHETIC_GROUP_ID.equals(p.getGroupId())
-                        && SYNTHETIC_ARTIFACT_ID.equals(p.getArtifactId()));
-        if (syntheticExists) {
-            return;
-        }
 
         // create synthetic project from a programmatically built Model
         MavenProject synthetic = createSyntheticProject(session);
@@ -79,22 +68,15 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
         session.setAllProjects(mutatedAll);
 
         // make target depend on synthetic => synthetic is upstream of target
-        boolean depAlreadyPresent = target.getDependencies().stream().anyMatch(d ->
-                SYNTHETIC_GROUP_ID.equals(d.getGroupId())
-                        && SYNTHETIC_ARTIFACT_ID.equals(d.getArtifactId())
-                        && SYNTHETIC_VERSION.equals(d.getVersion()));
-        if (!depAlreadyPresent) {
-            Dependency dep = new Dependency();
-            dep.setGroupId(SYNTHETIC_GROUP_ID);
-            dep.setArtifactId(SYNTHETIC_ARTIFACT_ID);
-            dep.setVersion(SYNTHETIC_VERSION);
-            // Use jar type instead of pom - even pom-packaged projects can have jar dependencies
-            // and jar dependencies in the reactor don't trigger the same resolution issues
-            dep.setType("jar");
-            dep.setScope("compile");
-            dep.setOptional(true);  // Optional to avoid strict resolution requirements
-            target.getModel().addDependency(dep);
-        }
+        Dependency dep = new Dependency();
+        dep.setGroupId(SYNTHETIC_GROUP_ID);
+        dep.setArtifactId(SYNTHETIC_ARTIFACT_ID);
+        dep.setVersion(SYNTHETIC_VERSION);
+        // Use jar type instead of pom - even pom-packaged projects can have jar dependencies
+        // and jar dependencies in the reactor don't trigger the same resolution issues
+        dep.setType("jar");
+        dep.setScope("compile");
+        target.getModel().addDependency(dep);
 
         logger.info("Added synthetic upstream project {}:{} and injected dependency into target {}:{}",
                 SYNTHETIC_GROUP_ID, SYNTHETIC_ARTIFACT_ID, target.getGroupId(), target.getArtifactId());
@@ -102,9 +84,6 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
 
     private MavenProject createSyntheticProject(MavenSession session) {
         try {
-            // Get the local repository path directly from the Maven request
-            File localRepo = session.getRequest().getLocalRepositoryPath();
-            logger.debug("Local repository: {}", localRepo.getAbsolutePath());
             
             // Create the Model programmatically  
             Model model = new Model();
@@ -112,25 +91,24 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
             model.setGroupId(SYNTHETIC_GROUP_ID);
             model.setArtifactId(SYNTHETIC_ARTIFACT_ID);
             model.setVersion(SYNTHETIC_VERSION);
-            model.setPackaging("jar");  // Use jar packaging so dependency resolution works
-            model.setName("IT Synthetic Upstream Project");
-            
-            // Prepare the directory and files in the local repository
-            File targetDir = new File(localRepo.getParentFile(), "it-synthetic-upstream");
-            targetDir.mkdirs();
-            File pomFile = new File(targetDir, "pom.xml");
+            model.setPackaging("jar");
+
+            // Prepare the directory and files
+            File workDir = new File(session.getExecutionRootDirectory(), "target/it-synthetic-upstream");
+            mkdirs(workDir);
+            File pomFile = new File(workDir, "pom.xml");
             
             // Serialize the Model to pom.xml
             MavenXpp3Writer writer = new MavenXpp3Writer();
             writer.write(Files.newBufferedWriter(pomFile.toPath()), model);
             
             // Create an empty jar file so the artifact can be resolved
-            File jarFile = new File(targetDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
+            File jarFile = new File(workDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
             createEmptyJarFile(jarFile);
             
             // Install to the local repository so Maven can resolve the dependency
             // This is critical - Maven's dependency resolution looks in the local repo
-            installToLocalRepository(localRepo, pomFile, jarFile);
+            installToLocalRepository(session, pomFile, jarFile);
             
             // Create and return the MavenProject
             MavenProject project = new MavenProject(model);
@@ -177,22 +155,28 @@ public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecyc
      * Install the POM and JAR to the local repository used by integration tests.
      * This mimics what 'mvn install' does, making the artifact available for dependency resolution.
      */
-    private void installToLocalRepository(File localRepo, File pomFile, File jarFile) throws IOException {
+    private void installToLocalRepository(MavenSession session, File pomFile, File jarFile) throws IOException {
+        File localRepo = session.getRequest().getLocalRepositoryPath();
+
         // Calculate the local repository path structure: groupId/artifactId/version/
         String groupPath = SYNTHETIC_GROUP_ID.replace('.', '/');
         File artifactDir = new File(localRepo, groupPath + "/" + SYNTHETIC_ARTIFACT_ID + "/" + SYNTHETIC_VERSION);
-        artifactDir.mkdirs();
+        mkdirs(artifactDir);
         
         // Copy POM file
         File localRepoPom = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".pom");
-        Files.copy(pomFile.toPath(), localRepoPom.toPath(), 
-                   java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(pomFile.toPath(), localRepoPom.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
         
         // Copy JAR file
         File localRepoJar = new File(artifactDir, SYNTHETIC_ARTIFACT_ID + "-" + SYNTHETIC_VERSION + ".jar");
-        Files.copy(jarFile.toPath(), localRepoJar.toPath(), 
-                   java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(jarFile.toPath(), localRepoJar.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
         
         logger.info("Installed synthetic artifact to local repository: {}", localRepoJar);
+    }
+
+    private static void mkdirs(File dir) {
+        if (!dir.mkdirs() && !dir.isDirectory()) {
+            throw new IllegalStateException("Failed to create directory: " + dir);
+        }
     }
 }

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/AddUpstreamSyntheticProjectParticipant.java
@@ -28,6 +28,13 @@ import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Maven lifecycle participant that adds a synthetic upstream project to the reactor and injects a dependency into a target project.<br/>
+ * To be used only in GIB's own integrations tests!
+ * <p/>
+ * This actually went quite a bit beyond adding a project <i>that is already part of the reactor</i> as a new dependency to another project in the reactor (as issue #1183 described).
+ * Instead, this participant <i>creates a new synthetic project on the fly, adds it to the reactor</i>, and injects a dependency into the target project.
+ */
 @Named
 @Singleton
 public class AddUpstreamSyntheticProjectParticipant extends AbstractMavenLifecycleParticipant {

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
@@ -79,7 +79,7 @@ public class MavenCoreExtensionIntegrationTest extends MavenIntegrationTestBase 
                 .contains("Building child4")
                 .contains("Building subchild41")
                 .contains("Building child6")
-                .contains("Building IT Synthetic Upstream Project 1.0.0-SNAPSHOT");
+                .contains("Building " + AddUpstreamSyntheticProjectParticipant.SYNTHETIC_ARTIFACT_ID);
     }
 
     private void writeExtensionsXml() throws IOException {

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.gitflowincrementalbuilder.config.Configuration;
+import io.github.gitflowincrementalbuilder.config.Property;
 
 /**
  * Integration test running the {@code mvn} command on a test project with active {@code gitflow-incremental-builder}
@@ -68,7 +69,13 @@ public class MavenCoreExtensionIntegrationTest extends MavenIntegrationTestBase 
 
     @Test
     public void afterOtherExtension() throws Exception {
-        final String output = executeBuild("-am", "-D" + AddUpstreamSyntheticProjectParticipant.PROP_TARGET_ARTIFACT_ID + "=child3", "-Dgib.rpdgm=auto");
+
+        String syntheticProjectTargetProperty =  "-D" + AddUpstreamSyntheticProjectParticipant.PROP_TARGET_ARTIFACT_ID + "=child3";
+        // sanity check:
+        assertThat(executeBuild(false, false,"-am", syntheticProjectTargetProperty, prop(Property.rebuildProjectDependencyGraphMode, "off")))
+                .doesNotContain("Building " + AddUpstreamSyntheticProjectParticipant.SYNTHETIC_ARTIFACT_ID);
+
+        final String output = executeBuild("-am", syntheticProjectTargetProperty);
 
         assertThat(output).doesNotContain("Building child1")
                 .doesNotContain("Building child2")

--- a/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/integration/MavenCoreExtensionIntegrationTest.java
@@ -66,6 +66,22 @@ public class MavenCoreExtensionIntegrationTest extends MavenIntegrationTestBase 
         }
     }
 
+    @Test
+    public void afterOtherExtension() throws Exception {
+        final String output = executeBuild("-am", "-D" + AddUpstreamSyntheticProjectParticipant.PROP_TARGET_ARTIFACT_ID + "=child3", "-Dgib.rpdgm=auto");
+
+        assertThat(output).doesNotContain("Building child1")
+                .doesNotContain("Building child2")
+                .doesNotContain("Building subchild1")
+                .doesNotContain("Building subchild42")
+                .contains("Building subchild2")
+                .contains("Building child3")
+                .contains("Building child4")
+                .contains("Building subchild41")
+                .contains("Building child6")
+                .contains("Building IT Synthetic Upstream Project 1.0.0-SNAPSHOT");
+    }
+
     private void writeExtensionsXml() throws IOException {
         String[] pluginGA = Configuration.PLUGIN_KEY.split(":");
         String extensionXml =
@@ -76,6 +92,12 @@ public class MavenCoreExtensionIntegrationTest extends MavenIntegrationTestBase 
                 "    <artifactId>" + pluginGA[1] + "</artifactId>\n" +
                 "    <version>" + gibVersion + "</version>\n" +
                 (classLoadingStrategyElementSupported ? "    <classLoadingStrategy>plugin</classLoadingStrategy>\n" : "") +
+                "  </extension>\n" +
+                // for AddUpstreamSyntheticProjectParticipant, must be defined after GIB to be executed first (sic!)
+                "  <extension>\n" +
+                "    <groupId>" + pluginGA[0] + "</groupId>\n" +
+                "    <artifactId>" + pluginGA[1] + "-it-support</artifactId>\n" +
+                "    <version>" + gibVersion + "</version>\n" +
                 "  </extension>\n" +
                 "</extensions>";
         Path extensionsPath = Files.createDirectory(repoPath.resolve(".mvn")).resolve("extensions.xml");

--- a/src/test/java/io/github/gitflowincrementalbuilder/mocks/MavenSessionMock.java
+++ b/src/test/java/io/github/gitflowincrementalbuilder/mocks/MavenSessionMock.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.mockito.quality.Strictness;
@@ -44,8 +43,6 @@ public class MavenSessionMock {
         when(mavenSession.getRequest()).thenReturn(request);
         when(mavenSession.getAllProjects()).thenReturn(projects);
         when(mavenSession.getProjects()).thenReturn(projects);
-        ProjectDependencyGraph dependencyGraphMock = mock(ProjectDependencyGraph.class);
-        when(mavenSession.getProjectDependencyGraph()).thenReturn(dependencyGraphMock);
         return mavenSession;
     }
 


### PR DESCRIPTION
Resolves #1183

Remaining todos:
- [x] add auto/on/off switch for the rebuild
- [x] add rebuild exception fallback to session's graph (but only for the general graph, not for the special allProjects case)
- [x] add runtime analysis (and possibly warning) to graph factory
- [x] add integration test
- [x] documentation